### PR TITLE
Update wait func for k8s workloads

### DIFF
--- a/manifests/implementation/capactio/capact/upgrade.yaml
+++ b/manifests/implementation/capactio/capact/upgrade.yaml
@@ -157,13 +157,13 @@ spec:
                       - name: helm-release
                         from: "{{inputs.artifacts.neo4j-helm-release}}"
               - - name: waiting-for-neo4j-to-be-ready
-                  template: wait-for-ready-pod
+                  template: wait-for-workload
                   arguments:
                     parameters:
                       - name: namespace
                         value: 'capact-system'
-                      - name: selector
-                        value: 'app.kubernetes.io/component=core'
+                      - name: workload
+                        value: 'sts/neo4j-neo4j-core'
                       - name: timeout
                         value: '300s'
 
@@ -178,13 +178,13 @@ spec:
                       - name: helm-release
                         from: "{{inputs.artifacts.ingress-nginx-helm-release}}"
               - - name: waiting-for-ingress-to-be-ready
-                  template: wait-for-ready-pod
+                  template: wait-for-workload
                   arguments:
                     parameters:
                       - name: namespace
                         value: 'capact-system'
-                      - name: selector
-                        value: 'app.kubernetes.io/component=controller'
+                      - name: workload
+                        value: 'deploy/ingress-nginx-controller'
                       - name: timeout
                         value: '90s'
 
@@ -263,19 +263,18 @@ spec:
               command: [ kubectl ]
               args: [ "annotate", "secret", "-n=capact-system", "argo-minio", 'kubed.appscode.com/sync=', "--overwrite" ]
 
-          - name: wait-for-ready-pod
+          - name: wait-for-workload
             inputs:
               parameters:
                 - name: namespace
-                - name: selector
+                - name: workload
                 - name: timeout
             container:
               image: bitnami/kubectl:1.18
               command: [ kubectl ]
               args:
-                - "wait"
-                - "--for=condition=ready"
-                - "pod"
+                - "rollout"
+                - "status"
+                - "{{inputs.parameters.workload}}"
                 - "-n={{inputs.parameters.namespace}}"
-                - "--selector={{inputs.parameters.selector}}"
                 - "--timeout={{inputs.parameters.timeout}}"


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Update wait func for k8s workloads

**Testing**

I changed manifests source on long-running cluster:

```bash
kubectl set env deploy/capact-hub-public -n capact-system -c="hub-public-populator" MANIFESTS_PATH="github.com/mszostok/hub-manifests?ref=fix-capact-upgrade"
```
Executed:
https://github.com/capactio/capact/runs/3241204084

Execution logs after `workload-wait`:
```log
Name:                capact-upgrade-pzwbp
Namespace:           capact-system
ServiceAccount:      capact-upgrade-pzwbp
Status:              Running
Created:             Wed Aug 04 14:01:23 +0200 (2 minutes ago)
Started:             Wed Aug 04 14:01:23 +0200 (2 minutes ago)
Duration:            2 minutes 51 seconds
ResourcesDuration:   1m47s*(1 cpu),1m47s*(100Mi memory)
Output Artifacts:
  capact-config:     &S3Artifact{S3Bucket:S3Bucket{Endpoint:argo-minio.capact-system.svc.cluster.local:9000,Bucket:argo-artifacts,Region:,Insecure:*true,AccessKeySecret:{{argo-minio} accesskey <nil>},SecretKeySecret:{{argo-minio} secretkey <nil>},RoleARN:,UseSDKCreds:false,},Key:capact-upgrade-pzwbp/capact-upgrade-pzwbp-2011278938/capact-config.tgz,}
  neo4j-helm-release: &S3Artifact{S3Bucket:S3Bucket{Endpoint:argo-minio.capact-system.svc.cluster.local:9000,Bucket:argo-artifacts,Region:,Insecure:*true,AccessKeySecret:{{argo-minio} accesskey <nil>},SecretKeySecret:{{argo-minio} secretkey <nil>},RoleARN:,UseSDKCreds:false,},Key:capact-upgrade-pzwbp/capact-upgrade-pzwbp-2011278938/neo4j-helm-release.tgz,}
  cert-manager-helm-release: &S3Artifact{S3Bucket:S3Bucket{Endpoint:argo-minio.capact-system.svc.cluster.local:9000,Bucket:argo-artifacts,Region:,Insecure:*true,AccessKeySecret:{{argo-minio} accesskey <nil>},SecretKeySecret:{{argo-minio} secretkey <nil>},RoleARN:,UseSDKCreds:false,},Key:capact-upgrade-pzwbp/capact-upgrade-pzwbp-2011278938/cert-manager-helm-release.tgz,}
  kubed-helm-release: &S3Artifact{S3Bucket:S3Bucket{Endpoint:argo-minio.capact-system.svc.cluster.local:9000,Bucket:argo-artifacts,Region:,Insecure:*true,AccessKeySecret:{{argo-minio} accesskey <nil>},SecretKeySecret:{{argo-minio} secretkey <nil>},RoleARN:,UseSDKCreds:false,},Key:capact-upgrade-pzwbp/capact-upgrade-pzwbp-2011278938/kubed-helm-release.tgz,}
  capact-helm-release: &S3Artifact{S3Bucket:S3Bucket{Endpoint:argo-minio.capact-system.svc.cluster.local:9000,Bucket:argo-artifacts,Region:,Insecure:*true,AccessKeySecret:{{argo-minio} accesskey <nil>},SecretKeySecret:{{argo-minio} secretkey <nil>},RoleARN:,UseSDKCreds:false,},Key:capact-upgrade-pzwbp/capact-upgrade-pzwbp-2011278938/capact-helm-release.tgz,}
  monitoring-helm-release: &S3Artifact{S3Bucket:S3Bucket{Endpoint:argo-minio.capact-system.svc.cluster.local:9000,Bucket:argo-artifacts,Region:,Insecure:*true,AccessKeySecret:{{argo-minio} accesskey <nil>},SecretKeySecret:{{argo-minio} secretkey <nil>},RoleARN:,UseSDKCreds:false,},Key:capact-upgrade-pzwbp/capact-upgrade-pzwbp-2011278938/monitoring-helm-release.tgz,}
  ingress-nginx-helm-release: &S3Artifact{S3Bucket:S3Bucket{Endpoint:argo-minio.capact-system.svc.cluster.local:9000,Bucket:argo-artifacts,Region:,Insecure:*true,AccessKeySecret:{{argo-minio} accesskey <nil>},SecretKeySecret:{{argo-minio} secretkey <nil>},RoleARN:,UseSDKCreds:false,},Key:capact-upgrade-pzwbp/capact-upgrade-pzwbp-2011278938/ingress-nginx-helm-release.tgz,}
  argo-helm-release: &S3Artifact{S3Bucket:S3Bucket{Endpoint:argo-minio.capact-system.svc.cluster.local:9000,Bucket:argo-artifacts,Region:,Insecure:*true,AccessKeySecret:{{argo-minio} accesskey <nil>},SecretKeySecret:{{argo-minio} secretkey <nil>},RoleARN:,UseSDKCreds:false,},Key:capact-upgrade-pzwbp/capact-upgrade-pzwbp-2011278938/argo-helm-release.tgz,}
  runner-context:    &S3Artifact{S3Bucket:S3Bucket{Endpoint:argo-minio.capact-system.svc.cluster.local:9000,Bucket:argo-artifacts,Region:,Insecure:*true,AccessKeySecret:{{argo-minio} accesskey <nil>},SecretKeySecret:{{argo-minio} secretkey <nil>},RoleARN:,UseSDKCreds:false,},Key:capact-upgrade-pzwbp/capact-upgrade-pzwbp-2848355594/runner-context.tgz,}
  capact-upgrade-neo4j-upgrade-helm-release: &S3Artifact{S3Bucket:S3Bucket{Endpoint:argo-minio.capact-system.svc.cluster.local:9000,Bucket:argo-artifacts,Region:,Insecure:*true,AccessKeySecret:{{argo-minio} accesskey <nil>},SecretKeySecret:{{argo-minio} secretkey <nil>},RoleARN:,UseSDKCreds:false,},Key:capact-upgrade-pzwbp/capact-upgrade-pzwbp-2322601013/helm-release.tgz,}
  capact-upgrade-ingress-upgrade-helm-release: &S3Artifact{S3Bucket:S3Bucket{Endpoint:argo-minio.capact-system.svc.cluster.local:9000,Bucket:argo-artifacts,Region:,Insecure:*true,AccessKeySecret:{{argo-minio} accesskey <nil>},SecretKeySecret:{{argo-minio} secretkey <nil>},RoleARN:,UseSDKCreds:false,},Key:capact-upgrade-pzwbp/capact-upgrade-pzwbp-3119375058/helm-release.tgz,}

STEP                                                                          TEMPLATE                                                          PODNAME                          DURATION  MESSAGE
 ● capact-upgrade-pzwbp                                                       capact-root
 ├---✔ inject-input-type-instances-b81713cf-cc5f-4693-9dab-4cf3474b0692-step  inject-input-type-instances-b81713cf-cc5f-4693-9dab-4cf3474b0692  capact-upgrade-pzwbp-2011278938  10s
 ├---✔ inject-runner-context-step                                             inject-runner-context                                             capact-upgrade-pzwbp-2848355594  4s
 ├---✔ populate-user-input-step                                               populate-user-input                                               capact-upgrade-pzwbp-3797647486  3s
 └---● start-entrypoint                                                       capact-upgrade
     ├-·-✔ apply-crds                                                         apply-capact-crd                                                  capact-upgrade-pzwbp-150564607   3s
     | ├-✔ gen-capact-helm-args                                               capact-upgrade-gen-capact-helm-args-template                      capact-upgrade-pzwbp-3321605346  20s
     | ├-✔ gen-global-helm-args                                               capact-upgrade-gen-global-helm-args-template                      capact-upgrade-pzwbp-3599193661  20s
     | └-✔ gen-neo4j-helm-args                                                capact-upgrade-gen-neo4j-helm-args-template                       capact-upgrade-pzwbp-2063931548  5s
     ├---✔ neo4j-upgrade                                                      capact-upgrade-neo4j-upgrade-helm
     |   ├---✔ helm-upgrade                                                   capact-upgrade-neo4j-upgrade-helm-upgrade                         capact-upgrade-pzwbp-4122614741  10s
     |   └---✔ output-helm-release                                            output-capact-upgrade-neo4j-upgrade-helm-release                  capact-upgrade-pzwbp-2322601013  6s
     ├---✔ waiting-for-neo4j-to-be-ready                                      wait-for-workload                                                 capact-upgrade-pzwbp-628712600   12s
     ├---✔ ingress-upgrade                                                    capact-upgrade-ingress-upgrade-helm
     |   ├---✔ helm-upgrade                                                   capact-upgrade-ingress-upgrade-helm-upgrade                       capact-upgrade-pzwbp-57426916    13s
     |   └---✔ output-helm-release                                            output-capact-upgrade-ingress-upgrade-helm-release                capact-upgrade-pzwbp-3119375058  6s
     ├---✔ waiting-for-ingress-to-be-ready                                    wait-for-workload                                                 capact-upgrade-pzwbp-2181294033  7s
     └---● cert-manager-upgrade                                               capact-upgrade-cert-manager-upgrade-helm
         └---◷ helm-upgrade                                                   capact-upgrade-cert-manager-upgrade-helm-upgrade                  capact-upgrade-pzwbp-92574071    6s
^C
 ▲ kubectl logs capact-upgrade-pzwbp-2181294033 main
I0804 12:04:01.434801      20 request.go:621] Throttling request took 1.121852365s, request: GET:https://10.4.0.1:443/apis/cert-manager.io/v1beta1?timeout=32s
deployment "ingress-nginx-controller" successfully rolled out
 ▲ kubectl logs capact-upgrade-pzwbp-628712600 main
I0804 12:03:13.089239      19 request.go:621] Throttling request took 1.133833708s, request: GET:https://10.4.0.1:443/apis/cert-manager.io/v1beta1?timeout=32s
partitioned roll out complete: 1 new pods have been updated...
```

## Related issue(s)

Fixes https://github.com/capactio/hub-manifests/issues/14