### PR TITLE
Validate manifests against latest Hub on CI

### DIFF
--- a/.github/workflows/branch-build.yaml
+++ b/.github/workflows/branch-build.yaml
@@ -59,16 +59,15 @@ jobs:
 
       - name: Wait for manifests
         run: |
-          MAX_ITERATIONS=$CAPACT_MANIFEST_WAITING_ITERATIONS
           set +e
           i=1
-          until [ $i -gt $MAX_ITERATIONS ]; do
+          until [ $i -gt $CAPACT_MANIFEST_WAITING_ITERATIONS ]; do
             ITEMS=$(capact hub interfaces get -ojson | jq length);
             if [ "$ITEMS" -gt 0 ]; then
               echo "Manifests are populated. Finishing...";
               exit 0;
             fi;
-            echo "Waiting for manifests..."
+            echo "$(date "+%F %R:%S") Waiting for manifests... (${i}/$CAPACT_MANIFEST_WAITING_ITERATIONS)"
             sleep 5;
             ((i++))
           done;

--- a/.github/workflows/branch-build.yaml
+++ b/.github/workflows/branch-build.yaml
@@ -67,13 +67,13 @@ jobs:
               echo "Manifests are populated. Finishing...";
               exit 0;
             fi;
-            echo "$(date "+%F %R:%S") Waiting for manifests... (${i}/$CAPACT_MANIFEST_WAITING_ITERATIONS)"
+            echo "$(date "+%F %R:%S"): Waiting for manifests... (${i}/${CAPACT_MANIFEST_WAITING_ITERATIONS})"
             sleep 5;
             ((i++))
           done;
           set -e
           
-          echo "Timeout exceeded"
+          echo "$(date "+%F %R:%S"): Timeout exceeded"
           exit 1      
 
       - name: Validate manifests

--- a/.github/workflows/branch-build.yaml
+++ b/.github/workflows/branch-build.yaml
@@ -15,16 +15,89 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      CAPACT_MANIFEST_REPOSITORY: git::${{ github.event.repository.clone_url }}
+      CAPACT_MANIFEST_BRANCH: ${{ github.sha }}
+      CAPACT_MANIFEST_WAITING_ITERATIONS: "100"
+      CAPACT_CREDENTIALS_STORE_FILE_PASSPHRASE: password
+      CAPACT_CREDENTIALS_STORE_BACKEND: file
+      CAPACT_GATEWAY_HOST: https://gateway.capact.local
+      CAPACT_GATEWAY_USERNAME: graphql
+      CAPACT_GATEWAY_PASSWORD: okon
+      CAPACT_INSTALL_COMPONENTS: neo4j,ingress-nginx,cert-manager,capact
+      CLUSTER_DUMP_DIR: output
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Download the latest Capact CLI for linux
+      - name: Download the latest Capact CLI
         run: |
           curl -Lo ./capact https://storage.googleapis.com/capactio-binaries/latest/capact-linux-amd64
           chmod +x ./capact
+          mv ./capact /usr/local/bin/capact
+
+      - name: Create kind cluster
+        run: |
+          capact env create kind --wait=5m
+
+      - name: Install Capact
+        # Minimal setup to have Public Hub up and running
+        run: |
+          capact install \
+            --verbose \
+            --environment=kind \
+            --helm-repo-url=@latest \
+            --increase-resource-limits=false \
+            --version=@latest \
+            --capact-overrides="global.gateway.auth.username=$CAPACT_GATEWAY_USERNAME,global.gateway.auth.password=$CAPACT_GATEWAY_PASSWORD,hub-public.populator.manifestsLocation.repository=$CAPACT_MANIFEST_REPOSITORY,hub-public.populator.manifestsLocation.branch=$CAPACT_MANIFEST_BRANCH" \
+            --install-component="$CAPACT_INSTALL_COMPONENTS" \
+            --timeout=10m
+
+      - name: Log in with Capact CLI
+        run: capact login "$CAPACT_GATEWAY_HOST" -u "$CAPACT_GATEWAY_USERNAME" -p "$CAPACT_GATEWAY_PASSWORD"
+
+      - name: Wait for manifests
+        run: |
+          MAX_ITERATIONS=$CAPACT_MANIFEST_WAITING_ITERATIONS
+          set +e
+          i=1
+          until [ $i -gt $MAX_ITERATIONS ]; do
+            ITEMS=$(capact hub interfaces get -ojson | jq length);
+            if [ "$ITEMS" -gt 0 ]; then
+              echo "Manifests are populated. Finishing...";
+              exit 0;
+            fi;
+            echo "Waiting for manifests..."
+            sleep 5;
+            ((i++))
+          done;
+          set -e
+          
+          echo "Timeout exceeded"
+          exit 1      
 
       - name: Validate manifests
+        run: capact manifest validate --server-side $(find ./manifests -regex ".*\.yaml")
+ 
+      - name: Dump cluster info
+        if: ${{ failure() }}
         run: |
-          ./capact manifest validate $(find ./manifests -regex ".*\.yaml")
+          echo "Installing kubectl"
+          curl --fail -Lo ./kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x ./kubectl
+          mv ./kubectl /usr/local/bin/kubectl
+          kubectl version --client
+
+          echo "Dumping cluster into ${CLUSTER_DUMP_DIR}..."
+          mkdir -p "${CLUSTER_DUMP_DIR}"
+          kubectl cluster-info dump --all-namespaces --output-directory="${CLUSTER_DUMP_DIR}"
+       
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: cluster_dump_${{github.sha}}
+          path: ${{env.CLUSTER_DUMP_DIR}}
+          retention-days: 5 # Default 90 days
+          if-no-files-found: ignore

--- a/.github/workflows/branch-build.yaml
+++ b/.github/workflows/branch-build.yaml
@@ -24,7 +24,7 @@ jobs:
       CAPACT_GATEWAY_HOST: https://gateway.capact.local
       CAPACT_GATEWAY_USERNAME: graphql
       CAPACT_GATEWAY_PASSWORD: okon
-      CAPACT_INSTALL_COMPONENTS: neo4j,ingress-nginx,cert-manager,capact
+      CAPACT_INSTALL_COMPONENTS: ingress-nginx,cert-manager,argo,kubed,neo4j,capact
       CLUSTER_DUMP_DIR: output
 
     steps:

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -91,3 +91,23 @@ jobs:
       - name: Validate manifests
         run: capact manifest validate --server-side $(find ./manifests -regex ".*\.yaml")
  
+      - name: Dump cluster info
+        if: ${{ failure() }}
+        run: |
+          echo "Installing kubectl"
+          curl --fail -Lo /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x /usr/local/bin/kubectl
+          kubectl version --client
+
+          echo "Dumping cluster into ${CLUSTER_DUMP_DIR}..."
+          mkdir -p "${CLUSTER_DUMP_DIR}"
+          kubectl cluster-info dump --all-namespaces --output-directory="${CLUSTER_DUMP_DIR}"
+       
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: cluster_dump_${{github.sha}}
+          path: ${{env.CLUSTER_DUMP_DIR}}
+          retention-days: 5 # Default 90 days
+          if-no-files-found: ignore

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -30,13 +30,15 @@ jobs:
     permissions:
       contents: read
     env:
+      CAPACT_MANIFEST_REPOSITORY: git::${{ github.event.pull_request.head.repo.clone_url }}
+      CAPACT_MANIFEST_BRANCH: ${{ github.event.pull_request.head.sha }}
+      CAPACT_MANIFEST_WAITING_ITERATIONS: "100"
       CAPACT_CREDENTIALS_STORE_FILE_PASSPHRASE: password
       CAPACT_CREDENTIALS_STORE_BACKEND: file
       CAPACT_GATEWAY_HOST: https://gateway.capact.local
       CAPACT_GATEWAY_USERNAME: graphql
       CAPACT_GATEWAY_PASSWORD: okon
-      CAPACT_MANIFEST_REPOSITORY: git::${{ github.event.pull_request.head.repo.clone_url }}
-      CAPACT_MANIFEST_BRANCH: ${{ github.event.pull_request.head.sha }}
+      CAPACT_INSTALL_COMPONENTS: neo4j,ingress-nginx,cert-manager,capact
       CLUSTER_DUMP_DIR: output
 
     steps:
@@ -56,14 +58,22 @@ jobs:
       - name: Install Capact
         # Minimal setup to have Public Hub up and running
         run: |
-          exit 1
+          capact install \
+            --verbose \
+            --environment=kind \
+            --helm-repo-url=@latest \
+            --increase-resource-limits=false \
+            --version=@latest \
+            --capact-overrides="global.gateway.auth.username=$CAPACT_GATEWAY_USERNAME,global.gateway.auth.password=$CAPACT_GATEWAY_PASSWORD,hub-public.populator.manifestsLocation.repository=$CAPACT_MANIFEST_REPOSITORY,hub-public.populator.manifestsLocation.branch=$CAPACT_MANIFEST_BRANCH" \
+            --install-component="$CAPACT_INSTALL_COMPONENTS" \
+            --timeout=10m
 
       - name: Log in with Capact CLI
         run: capact login "$CAPACT_GATEWAY_HOST" -u "$CAPACT_GATEWAY_USERNAME" -p "$CAPACT_GATEWAY_PASSWORD"
 
       - name: Wait for manifests
         run: |
-          MAX_ITERATIONS=100
+          MAX_ITERATIONS=$CAPACT_MANIFEST_WAITING_ITERATIONS
           set +e
           i=1
           until [ $i -gt $MAX_ITERATIONS ]; do

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -27,6 +27,7 @@ jobs:
   validation:
     name: Validate Hub manifests
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     permissions:
       contents: read
     env:
@@ -73,16 +74,15 @@ jobs:
 
       - name: Wait for manifests
         run: |
-          MAX_ITERATIONS=$CAPACT_MANIFEST_WAITING_ITERATIONS
           set +e
           i=1
-          until [ $i -gt $MAX_ITERATIONS ]; do
+          until [ $i -gt $CAPACT_MANIFEST_WAITING_ITERATIONS ]; do
             ITEMS=$(capact hub interfaces get -ojson | jq length);
             if [ "$ITEMS" -gt 0 ]; then
               echo "Manifests are populated. Finishing...";
               exit 0;
             fi;
-            echo "Waiting for manifests..."
+            echo "$(date "+%F %R:%S") Waiting for manifests... (${i}/$CAPACT_MANIFEST_WAITING_ITERATIONS)"
             sleep 5;
             ((i++))
           done;

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -37,6 +37,7 @@ jobs:
       CAPACT_GATEWAY_PASSWORD: okon
       CAPACT_MANIFEST_REPOSITORY: git::${{ github.event.pull_request.head.repo.clone_url }}
       CAPACT_MANIFEST_BRANCH: ${{ github.event.pull_request.head.sha }}
+      CLUSTER_DUMP_DIR: output
 
     steps:
       - name: Checkout repository
@@ -55,15 +56,7 @@ jobs:
       - name: Install Capact
         # Minimal setup to have Public Hub up and running
         run: |
-          capact install \
-            --verbose \
-            --environment=kind \
-            --helm-repo-url=@latest \
-            --increase-resource-limits=false \
-            --version=@latest \
-            --capact-overrides="global.gateway.auth.username=$CAPACT_GATEWAY_USERNAME,global.gateway.auth.password=$CAPACT_GATEWAY_PASSWORD,hub-public.populator.manifestsLocation.repository=$CAPACT_MANIFEST_REPOSITORY,hub-public.populator.manifestsLocation.branch=$CAPACT_MANIFEST_BRANCH" \
-            --install-component="neo4j,ingress-nginx,cert-manager,capact" \
-            --timeout=10m
+          exit 1
 
       - name: Log in with Capact CLI
         run: capact login "$CAPACT_GATEWAY_HOST" -u "$CAPACT_GATEWAY_USERNAME" -p "$CAPACT_GATEWAY_PASSWORD"
@@ -95,8 +88,9 @@ jobs:
         if: ${{ failure() }}
         run: |
           echo "Installing kubectl"
-          curl --fail -Lo /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-          chmod +x /usr/local/bin/kubectl
+          curl --fail -Lo ./kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x ./kubectl
+          mv ./kubectl /usr/local/bin/kubectl
           kubectl version --client
 
           echo "Dumping cluster into ${CLUSTER_DUMP_DIR}..."

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -59,30 +59,35 @@ jobs:
             --verbose \
             --environment=kind \
             --helm-repo-url=@latest \
+            --increase-resource-limits=false \
             --version=@latest \
             --capact-overrides="global.gateway.auth.username=$CAPACT_GATEWAY_USERNAME,global.gateway.auth.password=$CAPACT_GATEWAY_PASSWORD,hub-public.populator.manifestsLocation.repository=$CAPACT_MANIFEST_REPOSITORY,hub-public.populator.manifestsLocation.branch=$CAPACT_MANIFEST_BRANCH" \
             --install-component="neo4j,ingress-nginx,cert-manager,capact" \
             --timeout=10m
+
       - name: Log in with Capact CLI
-        run: |
-          capact login "$CAPACT_GATEWAY_HOST" -u "$CAPACT_GATEWAY_USERNAME" -p "$CAPACT_GATEWAY_PASSWORD"
+        run: capact login "$CAPACT_GATEWAY_HOST" -u "$CAPACT_GATEWAY_USERNAME" -p "$CAPACT_GATEWAY_PASSWORD"
+
       - name: Wait for manifests
         run: |
-          i=0
-          success=false
-          until [ $i -gt 36 ]; do
-            RESPONSE=$(capact hub interfaces get -oyaml);
-            echo 
-            if [ ${#RESPONSE} -gt 2 ]; then
-              echo "Response is not empty. Finishing...";
-              success=true
-              break;
+          MAX_ITERATIONS=100
+          set +e
+          i=1
+          until [ $i -gt $MAX_ITERATIONS ]; do
+            ITEMS=$(capact hub interfaces get -ojson | jq length);
+            if [ "$ITEMS" -gt 0 ]; then
+              echo "Manifests are populated. Finishing...";
+              exit 0;
             fi;
             echo "Waiting for manifests..."
             sleep 5;
             ((i++))
           done;
+          set -e
           
-          ! $success && echo "Timeout exceeded" && exit 1 
+          echo "Timeout exceeded"
+          exit 1      
+
       - name: Validate manifests
-        run: ./capact manifest validate --server-side $(find ./manifests -regex ".*\.yaml")
+        run: capact manifest validate --server-side $(find ./manifests -regex ".*\.yaml")
+ 

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -82,13 +82,13 @@ jobs:
               echo "Manifests are populated. Finishing...";
               exit 0;
             fi;
-            echo "$(date "+%F %R:%S") Waiting for manifests... (${i}/$CAPACT_MANIFEST_WAITING_ITERATIONS)"
+            echo "$(date "+%F %R:%S"): Waiting for manifests... (${i}/${CAPACT_MANIFEST_WAITING_ITERATIONS})"
             sleep 5;
             ((i++))
           done;
           set -e
           
-          echo "Timeout exceeded"
+          echo "$(date "+%F %R:%S"): Timeout exceeded"
           exit 1      
 
       - name: Validate manifests

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -38,7 +38,7 @@ jobs:
       CAPACT_GATEWAY_HOST: https://gateway.capact.local
       CAPACT_GATEWAY_USERNAME: graphql
       CAPACT_GATEWAY_PASSWORD: okon
-      CAPACT_INSTALL_COMPONENTS: neo4j,ingress-nginx,cert-manager,capact
+      CAPACT_INSTALL_COMPONENTS: ingress-nginx,cert-manager,argo,kubed,neo4j,capact
       CLUSTER_DUMP_DIR: output
 
     steps:

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -35,8 +35,8 @@ jobs:
       CAPACT_GATEWAY_HOST: https://gateway.capact.local
       CAPACT_GATEWAY_USERNAME: graphql
       CAPACT_GATEWAY_PASSWORD: okon
-      CAPACT_MANIFESTS_REPOSITORY: github.com/${{ github.repository }}
-      CAPACT_MANIFEST_BRANCH: ${{ github.sha }}
+      CAPACT_MANIFEST_REPOSITORY: git::${{ github.event.pull_request.head.repo.clone_url }}
+      CAPACT_MANIFEST_BRANCH: ${{ github.event.pull_request.head.sha }}
 
     steps:
       - name: Checkout repository
@@ -46,41 +46,43 @@ jobs:
         run: |
           curl -Lo ./capact https://storage.googleapis.com/capactio-binaries/latest/capact-linux-amd64
           chmod +x ./capact
+          mv ./capact /usr/local/bin/capact
 
       - name: Create kind cluster
         run: |
-          ./capact env create kind --wait=5m
+          capact env create kind --wait=5m
 
       - name: Install Capact
         # Minimal setup to have Public Hub up and running
         run: |
-          ./capact install \
+          capact install \
             --verbose \
             --environment=kind \
             --helm-repo-url=@latest \
             --version=@latest \
-            --capact-overrides="global.gateway.auth.username=$CAPACT_GATEWAY_USERNAME,global.gateway.auth.password=$CAPACT_GATEWAY_PASSWORD,hub-public.populator.manifestsLocation.repository=$CAPACT_MANIFESTS_REPOSITORY,hub-public.populator.manifestsLocation.branch=$CAPACT_MANIFEST_BRANCH" \
+            --capact-overrides="global.gateway.auth.username=$CAPACT_GATEWAY_USERNAME,global.gateway.auth.password=$CAPACT_GATEWAY_PASSWORD,hub-public.populator.manifestsLocation.repository=$CAPACT_MANIFEST_REPOSITORY,hub-public.populator.manifestsLocation.branch=$CAPACT_MANIFEST_BRANCH" \
             --install-component="neo4j,ingress-nginx,cert-manager,capact" \
             --timeout=10m
       - name: Log in with Capact CLI
         run: |
-          ./capact login "$CAPACT_GATEWAY_HOST" -u "$CAPACT_GATEWAY_USERNAME" -p "$CAPACT_GATEWAY_PASSWORD"
+          capact login "$CAPACT_GATEWAY_HOST" -u "$CAPACT_GATEWAY_USERNAME" -p "$CAPACT_GATEWAY_PASSWORD"
       - name: Wait for manifests
         run: |
           i=0
+          success=false
           until [ $i -gt 36 ]; do
-          
-            RESPONSE=$(./capact hub interfaces get -oyaml);
+            RESPONSE=$(capact hub interfaces get -oyaml);
             echo 
             if [ ${#RESPONSE} -gt 2 ]; then
-              echo "Completed";
-              exit 0;
+              echo "Response is not empty. Finishing...";
+              success=true
+              break;
             fi;
             echo "Waiting for manifests..."
             sleep 5;
             ((i++))
           done;
-          echo "Timeout has been exceeded";
-          exit 1
+          
+          ! $success && echo "Timeout exceeded" && exit 1 
       - name: Validate manifests
         run: ./capact manifest validate --server-side $(find ./manifests -regex ".*\.yaml")

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -29,15 +29,58 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      CAPACT_CREDENTIALS_STORE_FILE_PASSPHRASE: password
+      CAPACT_CREDENTIALS_STORE_BACKEND: file
+      CAPACT_GATEWAY_HOST: https://gateway.capact.local
+      CAPACT_GATEWAY_USERNAME: graphql
+      CAPACT_GATEWAY_PASSWORD: okon
+      CAPACT_MANIFESTS_REPOSITORY: github.com/${{ github.repository }}
+      CAPACT_MANIFEST_BRANCH: ${{ github.sha }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Download the latest Capact CLI for linux
+      - name: Download the latest Capact CLI
         run: |
           curl -Lo ./capact https://storage.googleapis.com/capactio-binaries/latest/capact-linux-amd64
           chmod +x ./capact
 
+      - name: Create kind cluster
+        run: |
+          ./capact env create kind --wait=5m
+
+      - name: Install Capact
+        # Minimal setup to have Public Hub up and running
+        run: |
+          ./capact install \
+            --verbose \
+            --environment=kind \
+            --helm-repo-url=@latest \
+            --version=@latest \
+            --capact-overrides="global.gateway.auth.username=$CAPACT_GATEWAY_USERNAME,global.gateway.auth.password=$CAPACT_GATEWAY_PASSWORD,hub-public.populator.manifestsLocation.repository=$CAPACT_MANIFESTS_REPOSITORY,hub-public.populator.manifestsLocation.branch=$CAPACT_MANIFEST_BRANCH" \
+            --install-component="neo4j,ingress-nginx,cert-manager,capact" \
+            --timeout=10m
+      - name: Log in with Capact CLI
+        run: |
+          ./capact login "$CAPACT_GATEWAY_HOST" -u "$CAPACT_GATEWAY_USERNAME" -p "$CAPACT_GATEWAY_PASSWORD"
+      - name: Wait for manifests
+        run: |
+          i=0
+          until [ $i -gt 36 ]; do
+          
+            RESPONSE=$(./capact hub interfaces get -oyaml);
+            echo 
+            if [ ${#RESPONSE} -gt 2 ]; then
+              echo "Completed";
+              exit 0;
+            fi;
+            echo "Waiting for manifests..."
+            sleep 5;
+            ((i++))
+          done;
+          echo "Timeout has been exceeded";
+          exit 1
       - name: Validate manifests
-        run: ./capact manifest validate $(find ./manifests -regex ".*\.yaml")
+        run: ./capact manifest validate --server-side $(find ./manifests -regex ".*\.yaml")


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Validate manifests against latest Hub

## Examples

- Success run on this PR: https://github.com/capactio/hub-manifests/runs/3309902578
- Success run on branch: https://github.com/pkosiec/hub-manifests/runs/3310008835, https://github.com/pkosiec/hub-manifests/runs/3310095902 (commit: https://github.com/pkosiec/hub-manifests/commit/05b0021d7cf581511ceec60c61d31fa09e8ea014 - different commit than above because of different `on.push.branches` value)
- Simulated failed run to see successful dump of cluster data: https://github.com/capactio/hub-manifests/runs/3309088961

I ran the job 4 times in a row to check its stability.

## Related issue(s)

https://github.com/capactio/capact/issues/398
