### PR TITLE
Automate release of hub-manifests

### DIFF
--- a/.github/workflows/make-release.yaml
+++ b/.github/workflows/make-release.yaml
@@ -1,0 +1,40 @@
+name: Make release
+
+# Required secrets:
+# GH_PAT - GitHub username with personal access token with permissions to make commits to repository, must be in format: "<username>:<PAT>"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version in SemVer (e.g. '0.5.0')
+        required: true
+      runner_image_tag:
+        description: Tag of the new runner images
+        required: true
+
+jobs:
+  make-release:
+    name: Make release
+    runs-on: ubuntu-latest
+    environment: Release
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - name: Setup Git credentials
+        # Replacing the GH Action token with PAT is required to trigger the branch-build workflow on a commit:
+        # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token
+        run: |
+          git remote remove origin
+          git remote add origin https://${{secrets.GH_PAT}}@github.com/${{github.repository}}.git
+          git config --global user.email "bot@capact.io"
+          git config --global user.name "Capact Bot"
+      - name: Make release commit
+        env:
+          RELEASE_VERSION: "${{ github.event.inputs.version }}"
+          RUNNER_IMAGES_TAG: "${{ github.event.inputs.runner_image_tag }}"
+        run: ./hack/make-release.sh

--- a/hack/make-release.sh
+++ b/hack/make-release.sh
@@ -24,6 +24,7 @@ main() {
 
   git tag "v${RELEASE_VERSION}"
   git push origin "${SOURCE_BRANCH}"
+  git push origin "v${RELEASE_VERSION}"
 
   if [ "${RELEASE_BRANCH}" != "${SOURCE_BRANCH}" ]; then
     git checkout -B "${RELEASE_BRANCH}"

--- a/hack/make-release.sh
+++ b/hack/make-release.sh
@@ -27,7 +27,7 @@ main() {
 
   if [ "${RELEASE_BRANCH}" != "${SOURCE_BRANCH}" ]; then
     git checkout -B "${RELEASE_BRANCH}"
-    git push "${RELEASE_BRANCH}"
+    git push origin "${RELEASE_BRANCH}"
   fi
 }
 

--- a/hack/make-release.sh
+++ b/hack/make-release.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+release::replace_runner_images() {
+  local -r tag="$1"
+
+  for manifest in ./manifests/implementation/runner/**/*.yaml; do
+    sed -i.bak -E "s|^(              image: ghcr.io/capactio/)(.+):(.+)|\1\2:${tag}" "${manifest}"
+  done
+
+  git add .
+  git commit -m "Update runner images to tag ${tag}"
+}
+
+[ -z "${RELEASE_VERSION}" ] && echo "Need to set RELEASE_VERSION" && exit 1;
+[ -z "${RUNNER_IMAGES_TAG}" ] && echo "Need to set RUNNER_IMAGES_TAG" && exit 1;
+
+SOURCE_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+RELEASE_VERSION_MAJOR_MINOR="$(echo "${RELEASE_VERSION}" | sed -E 's/([0-9]+\.[0-9])\.[0-9]/\1/g')"
+RELEASE_BRANCH="release-${RELEASE_VERSION_MAJOR_MINOR}"
+
+main() {
+  release::replace_runner_images "${RUNNER_IMAGES_TAG}"
+
+  git tag "v${RELEASE_VERSION}"
+  git push origin "${SOURCE_BRANCH}"
+
+  if [ "${RELEASE_BRANCH}" != "${SOURCE_BRANCH}" ]; then
+    git checkout -B "${RELEASE_BRANCH}"
+    git push "${RELEASE_BRANCH}"
+  fi
+}
+
+main

--- a/hack/make-release.sh
+++ b/hack/make-release.sh
@@ -7,7 +7,7 @@ release::replace_runner_images() {
   local manifests="$(find ./manifests/implementation/runner -iname "*.yaml" -a -not -path "*cloudsql*")"
 
   for manifest in $manifests; do
-    sed -i.bak -E "s|^(              image: ghcr.io/capactio/)(.+):(.+)|\1\2:${tag}|" "${manifest}"
+    sed -i.bak -E "s|^(              image: ghcr.io/capactio/)(pr/)?(.+):(.+)|\1\3:${tag}|" "${manifest}"
   done
 }
 

--- a/hack/make-release.sh
+++ b/hack/make-release.sh
@@ -5,7 +5,7 @@ release::replace_runner_images() {
   local -r tag="$1"
 
   for manifest in ./manifests/implementation/runner/**/*.yaml; do
-    sed -i.bak -E "s|^(              image: ghcr.io/capactio/)(.+):(.+)|\1\2:${tag}" "${manifest}"
+    sed -i.bak -E "s|^(              image: ghcr.io/capactio/)(.+):(.+)|\1\2:${tag}|" "${manifest}"
   done
 
   git add .

--- a/hack/make-release.sh
+++ b/hack/make-release.sh
@@ -4,12 +4,11 @@ set -e
 release::replace_runner_images() {
   local -r tag="$1"
 
-  for manifest in ./manifests/implementation/runner/**/*.yaml; do
+  local manifests="$(find ./manifests/implementation/runner -iname "*.yaml" -a -not -path "*cloudsql*")"
+
+  for manifest in $manifests; do
     sed -i.bak -E "s|^(              image: ghcr.io/capactio/)(.+):(.+)|\1\2:${tag}|" "${manifest}"
   done
-
-  git add .
-  git commit -m "Update runner images to tag ${tag}"
 }
 
 [ -z "${RELEASE_VERSION}" ] && echo "Need to set RELEASE_VERSION" && exit 1;
@@ -21,6 +20,9 @@ RELEASE_BRANCH="release-${RELEASE_VERSION_MAJOR_MINOR}"
 
 main() {
   release::replace_runner_images "${RUNNER_IMAGES_TAG}"
+
+  git add .
+  git commit -m "Update runner images to tag ${tag}"
 
   git tag "v${RELEASE_VERSION}"
   git push origin "${SOURCE_BRANCH}"


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Add script and workflow to automate release

## Testing

1. Reset `main` of your fork to this branch
2. Run the workflow from `main`, use `0.5.0` as version and `abcd` as runner image tag
3. Verify `main` has been updated and branch `release-0.5` created
4. Run the workflow from `release-0.5`, use `0.5.1` as version and `azxs` as runner image tag
5. Verify `release-0.5` has been updated

My runs:

`0.5.0` run - https://github.com/Trojan295/hub-manifests/runs/3441157749?check_suite_focus=true
`0.5.1` run - https://github.com/Trojan295/hub-manifests/runs/3441187298?check_suite_focus=true

## Related issue(s)

<!-- If you refer to a particular issue, provide its number. 
To close the issue after the pull request merge, use `Resolves #123` or `Fixes #123`.
Otherwise, use `See also #123` or just `#123`. -->
