### PR TITLE
Add 'hello world' manifests

### DIFF
--- a/manifests/implementation/capactio/capact/hello.yaml
+++ b/manifests/implementation/capactio/capact/hello.yaml
@@ -1,0 +1,53 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Implementation
+metadata:
+  prefix: cap.implementation.capactio.capact
+  name: hello
+  displayName: "Hello Capact"
+  description: "Capact Hello Action"
+  documentationURL: https://capact.dev
+  supportURL: https://capact.dev
+  license:
+    name: "Apache 2.0"
+  maintainers:
+    - email: team-dev@capact.dev
+      name: Capact Dev Team
+      url: https://capact.dev
+
+spec:
+  appVersion: "0.3.x"
+  outputTypeInstanceRelations: {}
+
+  implements:
+    - path: cap.interface.capactio.capact.hello
+      revision: 0.1.0
+
+  requires:
+    cap.core.type.platform:
+      oneOf:
+        - name: kubernetes
+          revision: 0.1.0
+
+  imports:
+    - interfaceGroupPath: cap.interface.runner.argo
+      alias: argo
+      methods:
+        - name: run
+          revision: 0.1.0
+    - interfaceGroupPath: cap.interface.capactio.capact
+      alias: capact
+      methods:
+        - name: say
+          revision: 0.1.0
+
+  action:
+    runnerInterface: argo.run
+    args:
+      workflow:
+        entrypoint: hello
+        templates:
+        - name: hello
+          steps:
+            - - name: say
+                capact-action: capact.say

--- a/manifests/implementation/capactio/capact/say.yaml
+++ b/manifests/implementation/capactio/capact/say.yaml
@@ -1,0 +1,49 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Implementation
+metadata:
+  prefix: cap.implementation.capactio.capact
+  name: scream
+  displayName: "Scream CAPACT"
+  description: "Capact SCREAM Action"
+  documentationURL: https://capact.dev
+  supportURL: https://capact.dev
+  license:
+    name: "Apache 2.0"
+  maintainers:
+    - email: team-dev@capact.dev
+      name: Capact Dev Team
+      url: https://capact.dev
+
+spec:
+  appVersion: "0.3.x"
+  outputTypeInstanceRelations: {}
+
+  implements:
+    - path: cap.interface.capactio.capact.say
+      revision: 0.1.0
+
+  requires:
+    cap.core.type.platform:
+      oneOf:
+        - name: kubernetes
+          revision: 0.1.0
+
+  imports:
+    - interfaceGroupPath: cap.interface.runner.argo
+      alias: argo
+      methods:
+        - name: run
+          revision: 0.1.0
+
+  action:
+    runnerInterface: argo.run
+    args:
+      workflow:
+        entrypoint: say
+        templates:
+        - name: say
+          container:
+            image: docker/whalesay:latest
+            command: [cowsay]
+            args: ["HELLO CAPACT!!!"]

--- a/manifests/implementation/capactio/capact/scream.yaml
+++ b/manifests/implementation/capactio/capact/scream.yaml
@@ -1,0 +1,49 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Implementation
+metadata:
+  prefix: cap.implementation.capactio.capact
+  name: say
+  displayName: "Say Capact"
+  description: "Capact Say Hello Action"
+  documentationURL: https://capact.dev
+  supportURL: https://capact.dev
+  license:
+    name: "Apache 2.0"
+  maintainers:
+    - email: team-dev@capact.dev
+      name: Capact Dev Team
+      url: https://capact.dev
+
+spec:
+  appVersion: "0.3.x"
+  outputTypeInstanceRelations: {}
+
+  implements:
+    - path: cap.interface.capactio.capact.say
+      revision: 0.1.0
+
+  requires:
+    cap.core.type.platform:
+      oneOf:
+        - name: kubernetes
+          revision: 0.1.0
+
+  imports:
+    - interfaceGroupPath: cap.interface.runner.argo
+      alias: argo
+      methods:
+        - name: run
+          revision: 0.1.0
+
+  action:
+    runnerInterface: argo.run
+    args:
+      workflow:
+        entrypoint: say
+        templates:
+        - name: say
+          container:
+            image: docker/whalesay:latest
+            command: [cowsay]
+            args: ["hello capact"]

--- a/manifests/interface/capactio/capact/hello.yaml
+++ b/manifests/interface/capactio/capact/hello.yaml
@@ -1,0 +1,18 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Interface
+metadata:
+  prefix: cap.interface.capactio.capact
+  name: hello
+  displayName: "Hello"
+  description: "Capact Hello Action"
+  documentationURL: https://capact.dev
+  supportURL: https://capact.dev
+  maintainers:
+    - email: team-dev@capact.dev
+      name: Capact Dev Team
+      url: https://capact.dev
+
+spec:
+  input: {}
+  output: {}

--- a/manifests/interface/capactio/capact/say.yaml
+++ b/manifests/interface/capactio/capact/say.yaml
@@ -1,0 +1,18 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Interface
+metadata:
+  prefix: cap.interface.capactio.capact
+  name: say
+  displayName: "Say"
+  description: "Simple Capact Action"
+  documentationURL: https://capact.dev
+  supportURL: https://capact.dev
+  maintainers:
+    - email: team-dev@capact.dev
+      name: Capact Dev Team
+      url: https://capact.dev
+
+spec:
+  input: {}
+  output: {}


### PR DESCRIPTION
# Description

Changes proposed in this pull request:

- Add simple "Hello world" manifests.

## Testing

Create a new action

```bash
capact act create --name hello cap.interface.capactio.capact.hello
```

Wait for action to have a status `READY_TO_RUN`. To get a status run:

```bash
capact act get hello
```

When status is `READY_TO_RUN`, run action:

```bash
capact act run hello
```

Watch the progress:

```bash
capact act watch hello
```

When command finished note the name of the last Pod. It's in the column `PODNAME`. See it's logs:

```bash
kubectl logs <PODNAME>
```



## Related issue(s)

Closes #34 
