### PR TITLE
Use the latest CRD directly from the GitHub repo

### DIFF
--- a/manifests/implementation/capactio/capact/upgrade.yaml
+++ b/manifests/implementation/capactio/capact/upgrade.yaml
@@ -71,7 +71,7 @@ spec:
                   arguments:
                     parameters:
                      - name: crdURL
-                       value: https://storage.googleapis.com/capactio-latest-charts/crds/core.capact.io_actions.yaml
+                       value: https://raw.githubusercontent.com/capactio/capact/main/deploy/kubernetes/crds/core.capact.io_actions.yaml
 
                 - name: gen-global-helm-args
                   capact-action: jinja2.template


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

## Description

Changes proposed in this pull request:

- Use the latest CRD directly from the GitHub repo. 


NOTE: This PR fixes bug with outdated CRD version. This issue https://github.com/capactio/hub-manifests/issues/29 still needs to be addressed. Mentioned issue can be even simplified if we will decide to use `capact install` in the Capact Upgrade Action manifests, as we will have it out-of-the-box. When the Capact Upgrade manifests were introduced, we didn't have `capact install`. Now it seems reasonable to maintain only one option to update Capact.

## Related issue(s)

- https://github.com/capactio/capact/issues/577