### PR TITLE
Adjust GitHub workflows to new populator scheme

### DIFF
--- a/.github/workflows/branch-build.yaml
+++ b/.github/workflows/branch-build.yaml
@@ -50,7 +50,7 @@ jobs:
             --helm-repo=@latest \
             --increase-resource-limits=false \
             --version=@latest \
-            --capact-overrides="global.gateway.auth.username=$CAPACT_GATEWAY_USERNAME,global.gateway.auth.password=$CAPACT_GATEWAY_PASSWORD,hub-public.populator.manifestsLocation.repository=$CAPACT_MANIFEST_REPOSITORY,hub-public.populator.manifestsLocation.branch=$CAPACT_MANIFEST_BRANCH" \
+            --capact-overrides="global.gateway.auth.username=$CAPACT_GATEWAY_USERNAME,global.gateway.auth.password=$CAPACT_GATEWAY_PASSWORD,hub-public.populator.manifestsLocations[0].repository=$CAPACT_MANIFEST_REPOSITORY,hub-public.populator.manifestsLocations[0].branch=$CAPACT_MANIFEST_BRANCH" \
             --install-component="$CAPACT_INSTALL_COMPONENTS" \
             --timeout=10m
 

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -65,7 +65,7 @@ jobs:
             --helm-repo=@latest \
             --increase-resource-limits=false \
             --version=@latest \
-            --capact-overrides="global.gateway.auth.username=$CAPACT_GATEWAY_USERNAME,global.gateway.auth.password=$CAPACT_GATEWAY_PASSWORD,hub-public.populator.manifestsLocation.repository=$CAPACT_MANIFEST_REPOSITORY,hub-public.populator.manifestsLocation.branch=$CAPACT_MANIFEST_BRANCH" \
+            --capact-overrides="global.gateway.auth.username=$CAPACT_GATEWAY_USERNAME,global.gateway.auth.password=$CAPACT_GATEWAY_PASSWORD,hub-public.populator.manifestsLocations[0].repository=$CAPACT_MANIFEST_REPOSITORY,hub-public.populator.manifestsLocations[0].branch=$CAPACT_MANIFEST_BRANCH" \
             --install-component="$CAPACT_INSTALL_COMPONENTS" \
             --timeout=10m
 


### PR DESCRIPTION
## Description
Changes proposed in this pull request:

- Adjust GitHub workflows to new populator scheme.

There was a change of name `manifestsLocation` to `manifestsLocations`, as now we support populating manifest from many sources.

## Related issue(s)
- https://github.com/capactio/capact/issues/560
