### PR TITLE
Fixes after validation of TypeInstances

### DIFF
--- a/manifests/implementation/aws/rds/postgresql/install.yaml
+++ b/manifests/implementation/aws/rds/postgresql/install.yaml
@@ -188,7 +188,7 @@ spec:
                             output:
                               goTemplate:
                                 host: "{{ .instance_ip_addr }}"
-                                port: "{{ .port }}"
+                                port: {{ .port }}
                                 defaultDBName: "{{ .defaultDBName }}"
                                 superuser:
                                   username: "{{ .username }}"

--- a/manifests/implementation/bitnami/postgresql/install.yaml
+++ b/manifests/implementation/bitnami/postgresql/install.yaml
@@ -105,7 +105,7 @@ spec:
                             output:
                               goTemplate: |
                                 host: '{{ template "common.names.fullname" . }}.{{ .Release.Namespace }}'
-                                port: '{{ template "postgresql.port" . }}'
+                                port: {{ template "postgresql.port" . }}
                                 defaultDBName: '{{ template "postgresql.database" . }}'
                                 superuser:
                                   # It cannot be changed

--- a/manifests/implementation/capactio/capact/validation/action/update.yaml
+++ b/manifests/implementation/capactio/capact/validation/action/update.yaml
@@ -73,4 +73,4 @@ spec:
             container:
               image: alpine:latest
               command: ["sh", "-c"]
-              args: ["cat /input-parameters | grep success && echo 'updated: true' | tee /update && sleep 2"]
+              args: ["cat /input-parameters | grep success && echo 'key: \"true\"' | tee /update && sleep 2"]

--- a/manifests/implementation/gcp/cloudsql/postgresql/install-0.1.0.yaml
+++ b/manifests/implementation/gcp/cloudsql/postgresql/install-0.1.0.yaml
@@ -98,7 +98,7 @@ spec:
                             output:
                               goTemplate:
                                 host: "{{ (index .DBInstance.IpAddresses 0).IpAddress  }}"
-                                port: "{{ .Port }}"
+                                port: {{ .Port }}
                                 defaultDBName: "{{ .DefaultDBName }}"
                                 superuser:
                                   username: "{{ .Username }}"

--- a/manifests/implementation/postgresql/create-db.yaml
+++ b/manifests/implementation/postgresql/create-db.yaml
@@ -77,7 +77,6 @@ spec:
                             cat <<EOF > /database.yml
                             name: <@name@>
                             owner: <@owner@>
-                            tablespace: ""
                             EOF
                       - name: input-parameters
                         from: "{{inputs.artifacts.postgresql}}"

--- a/manifests/type/capactio/capact/validation/download.yaml
+++ b/manifests/type/capactio/capact/validation/download.yaml
@@ -21,7 +21,7 @@ spec:
         "title": "The schema for download Type",
         "examples": [
           {
-            "key": true
+            "key": "example key"
           }
         ],
         "required": [
@@ -30,7 +30,7 @@ spec:
         "properties": {
           "key": {
            "$id": "#/properties/key",
-           "type": "boolean",
+           "type": "string",
            "title": "Key"
           }
         },

--- a/manifests/type/capactio/capact/validation/single-key.yaml
+++ b/manifests/type/capactio/capact/validation/single-key.yaml
@@ -21,7 +21,7 @@ spec:
         "title": "The schema for single key Type",
         "examples": [
           {
-            "key": true
+            "key": "example key"
           }
         ],
         "required": [
@@ -30,7 +30,7 @@ spec:
         "properties": {
           "key": {
            "$id": "#/properties/key",
-           "type": "boolean",
+           "type": "string",
            "title": "Key"
           }
         },

--- a/manifests/type/capactio/capact/validation/update.yaml
+++ b/manifests/type/capactio/capact/validation/update.yaml
@@ -21,7 +21,7 @@ spec:
         "title": "The schema for update Type",
         "examples": [
           {
-            "key": true
+            "key": "example key"
           }
         ],
         "required": [
@@ -30,7 +30,7 @@ spec:
         "properties": {
           "key": {
            "$id": "#/properties/key",
-           "type": "boolean",
+           "type": "string",
            "title": "Key"
           }
         },

--- a/manifests/type/capactio/capact/validation/upload.yaml
+++ b/manifests/type/capactio/capact/validation/upload.yaml
@@ -21,7 +21,7 @@ spec:
         "title": "The schema for upload Type",
         "examples": [
           {
-            "key": true
+            "key": "example key"
           }
         ],
         "required": [
@@ -30,7 +30,7 @@ spec:
         "properties": {
           "key": {
            "$id": "#/properties/key",
-           "type": "boolean",
+           "type": "string",
            "title": "Key"
           }
         },


### PR DESCRIPTION
## Description
Changes proposed in this pull request:
- change port in implementation which uses Postgres to be number (not string),
- remote tablespace in Postgres - not used by TypeInstance,
- in capact/validation change key to be string, not boolean as mainly that how we use it in integration tests. 

## Related issue(s)
- https://github.com/capactio/capact/issues/544
