### PR TITLE
Update binary location in Google Storage

### DIFF
--- a/.github/workflows/branch-build.yaml
+++ b/.github/workflows/branch-build.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Download the latest Capact CLI
         run: |
-          curl -Lo ./capact https://storage.googleapis.com/capactio-binaries/latest/capact-linux-amd64
+          curl -Lo ./capact https://storage.googleapis.com/capactio-binaries/latest/capact_linux_amd64/capact
           chmod +x ./capact
           mv ./capact /usr/local/bin/capact
 

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Download the latest Capact CLI
         run: |
-          curl -Lo ./capact https://storage.googleapis.com/capactio-binaries/latest/capact-linux-amd64
+          curl -Lo ./capact https://storage.googleapis.com/capactio-binaries/latest/capact_linux_amd64/capact
           chmod +x ./capact
           mv ./capact /usr/local/bin/capact
 


### PR DESCRIPTION
## Description

Changes proposed in this pull request:
- update `capact` binary location in Google Storage for CI

After adding support of `brew`, there was a change of localization of capact binaries. This PR mitigates that.

## Related issue(s)
- https://github.com/capactio/capact/issues/587
