### PR TITLE
Introduce Helm storage backends installation manifests

### DIFF
--- a/manifests/implementation/capactio/capact/validation/action/passing-b.yaml
+++ b/manifests/implementation/capactio/capact/validation/action/passing-b.yaml
@@ -40,7 +40,7 @@ spec:
           revision: 0.1.0
     cap.core.type.hub.storage:
       allOf:
-        - name: cap.type.helm.storage
+        - name: cap.type.helm.release.storage
           revision: 0.1.0
           alias: helm-storage
 

--- a/manifests/implementation/helm/storage/install.yaml
+++ b/manifests/implementation/helm/storage/install.yaml
@@ -1,0 +1,275 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Implementation
+metadata:
+  prefix: "cap.implementation.helm.storage"
+  name: install
+  displayName: "Install"
+  description: "Installs Helm Release and Helm Template storage backends"
+  documentationURL: https://capact.io/docs
+  supportURL: https://helm.sh/
+  iconURL: https://storage.googleapis.com/dashboard-icons/helm.svg
+  maintainers:
+    - email: team-dev@capact.io
+      name: Capact Dev Team
+      url: https://capact.io
+  license:
+    name: "Apache 2.0"
+
+spec:
+  appVersion: "0.x"
+  additionalInput:
+    parameters:
+      additional-parameters:
+        typeRef:
+          path: "cap.type.helm.storage.install-input"
+          revision: 0.1.0
+
+  outputTypeInstanceRelations:
+    helm-release-storage:
+      uses:
+        - helm-release
+    helm-template-storage:
+      uses:
+        - helm-release
+
+  implements:
+    - path: "cap.interface.helm.storage.install"
+      revision: 0.1.0
+
+  requires:
+    cap.core.type.platform:
+      oneOf:
+        - name: kubernetes
+          revision: 0.1.0
+
+  imports:
+    - interfaceGroupPath: cap.interface.runner.argo
+      alias: argo
+      methods:
+        - name: run
+          revision: 0.1.0
+    - interfaceGroupPath: cap.interface.templating.jinja2
+      alias: jinja2
+      methods:
+        - name: template
+          revision: 0.1.0
+    - interfaceGroupPath: cap.interface.runner.helm
+      alias: helm
+      methods:
+        - name: install
+          revision: 0.1.0
+
+  action:
+    runnerInterface: argo.run
+    args:
+      workflow:
+        entrypoint: deploy
+        templates:
+          - name: deploy
+            inputs:
+              artifacts:
+                - name: additional-parameters
+                  optional: true
+            outputs:
+              artifacts: []
+            steps:
+
+              - - name: create-helm-args
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{inputs.artifacts.input-parameters}}"
+                      - name: configuration
+                        raw:
+                          data:
+                      - name: template
+                        raw:
+                          data: |
+                            generateName: true
+                            chart:
+                              name: "helm-storage-backend"
+                              repo: "https://storage.googleapis.com/capactio-latest-charts"
+                              version: "0.6.0-bb9b779"
+                            values:
+                              affinity: <@ additionalinput.affinity | default({}) | tojson @>
+                              autoscaling:
+                                enabled: <@ additionalinput.autoscaling.enabled | default(false) | tojson @>
+                                maxReplicas: <@ additionalinput.autoscaling.maxReplicas | default(100) @>
+                                minReplicas: <@ additionalinput.autoscaling.minReplicas | default(1) @>
+                                targetCPUUtilizationPercentage: <@ additionalinput.autoscaling.targetCPUUtilizationPercentage | default(80) @>
+                              global:
+                                containerRegistry:
+                                  overrideTag: <@ additionalinput.global.containerRegistry.overrideTag | default("latest") @>
+                                  path: <@ additionalinput.global.containerRegistry.path | default("ghcr.io/capactio") @>
+                              helmReleaseBackend:
+                                enabled: <@ additionalinput.helmReleaseBackend.enabled | default(true) | tojson @>
+                                service:
+                                  port: <@ additionalinput.helmReleaseBackend.service.port | default(50051) @>
+                                  type: <@ additionalinput.helmReleaseBackend.service.type | default("ClusterIP") @>
+                              helmTemplateBackend:
+                                enabled: <@ additionalinput.helmTemplateBackend.enabled | default(true) | tojson @>
+                                service:
+                                  port: <@ additionalinput.helmTemplateBackend.service.port | default(50052) @>
+                                  type: <@ additionalinput.helmTemplateBackend.service.type | default("ClusterIP") @>
+                              image:
+                                name: <@ additionalinput.image.name | default("helm-storage-backend") @>
+                                pullPolicy: <@ additionalinput.image.pullPolicy | default("IfNotPresent") @>
+                              imagePullSecrets: <@ additionalinput.imagePullSecrets | default([]) | tojson @>
+                              nodeSelector: <@ additionalinput.nodeSelector | default({}) | tojson @>
+                              podAnnotations: <@ additionalinput.podAnnotations | default({}) | tojson @>
+                              podSecurityContext: <@ additionalinput.podSecurityContext | default({}) | tojson @>
+                              replicaCount: <@ additionalinput.replicaCount | default(1) @>
+                              resources:
+                                limits:
+                                  cpu: <@ additionalinput.resources.limits.cpu | default("100m") @>
+                                  memory: <@ additionalinput.resources.limits.memory | default("32Mi") @>
+                                requests:
+                                  cpu: <@ additionalinput.resources.requests.cpu | default("30m") @>
+                                  memory: <@ additionalinput.resources.requests.memory | default("16Mi") @>
+                              securityContext: <@ additionalinput.securityContext | default({}) | tojson @>
+                              tolerations: <@ additionalinput.tolerations | default([]) | tojson @>
+                            output:
+                              goTemplate: |
+                                releaseSvcUrl: '{{ include "helm-storage-backend.fullname" . }}-release.{{ .Release.Namespace }}:{{ .Values.helmReleaseBackend.service.port }}'
+                                templateSvcUrl: '{{ include "helm-storage-backend.fullname" . }}-template.{{ .Release.Namespace }}:{{ .Values.helmTemplateBackend.service.port }}'
+
+              - - name: helm-install
+                  capact-action: helm.install
+                  capact-outputTypeInstances:
+                    - name: helm-release
+                      from: helm-release
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{steps.create-helm-args.outputs.artifacts.render}}"
+                      - name: runner-context
+                        from: "{{workflow.outputs.artifacts.runner-context}}"
+
+              - - name: render-output-script
+                  capact-action: jinja2.template
+                  arguments:
+                    artifacts:
+                      - name: template
+                        raw:
+                          data: |
+                            #!/bin/sh                            
+
+                            set -e
+                            
+                            cat << EOF > /tmp/helm-release
+                            url: "<@ releaseSvcUrl @>"
+                            acceptValue: false
+                            schema: |
+                              {
+                                "$schema": "http://json-schema.org/draft-07/schema",
+                                "type": "object",
+                                "required": [
+                                  "name",
+                                  "namespace",
+                                  "chartLocation"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "$id": "#/properties/context/properties/name",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "$id": "#/properties/context/properties/namespace",
+                                    "type": "string"
+                                  },
+                                  "chartLocation": {
+                                    "$id": "#/properties/context/properties/chartLocation",
+                                    "type": "string"
+                                  },
+                                  "driver": {
+                                    "$id": "#/properties/context/properties/driver",
+                                    "type": "string",
+                                    "default": "secrets",
+                                    "enum": [
+                                      "secrets",
+                                      "configmaps",
+                                      "sql"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            EOF
+                            
+                            cat << EOF > /tmp/helm-template
+                            url: "<@ templateSvcUrl @>"
+                            acceptValue: false
+                            schema: |
+                              {
+                                "$schema": "http://json-schema.org/draft-07/schema",
+                                "type": "object",
+                                "required": [
+                                  "name",
+                                  "namespace",
+                                  "chartLocation"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "$id": "#/properties/context/properties/name",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "$id": "#/properties/context/properties/namespace",
+                                    "type": "string"
+                                  },
+                                  "chartLocation": {
+                                    "$id": "#/properties/context/properties/chartLocation",
+                                    "type": "string"
+                                  },
+                                  "driver": {
+                                    "$id": "#/properties/context/properties/driver",
+                                    "type": "string",
+                                    "default": "secrets",
+                                    "enum": [
+                                      "secrets",
+                                      "configmaps",
+                                      "sql"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            EOF
+                      - name: input-parameters
+                        from: "{{steps.helm-install.outputs.artifacts.additional}}"
+                      - name: configuration
+                        raw:
+                          data: ""
+
+              - - name: produce-output
+                  template: produce-output-tmpl
+                  capact-outputTypeInstances:
+                    - name: helm-release-storage
+                      from: helm-release
+                    - name: helm-template-storage
+                      from: helm-template
+                  arguments:
+                    artifacts:
+                      - name: script
+                        from: "{{steps.render-output-script.outputs.artifacts.render}}"
+
+          - name: produce-output-tmpl
+            inputs:
+              parameters:
+              artifacts:
+                - name: script
+                  path: /script
+                  mode: 0755
+            outputs:
+              artifacts:
+                - name: helm-release
+                  path: /tmp/helm-release
+                - name: helm-template
+                  path: /tmp/helm-template
+            container:
+              image: alpine:3.7
+              command: [ sh ]
+              args:
+                - "{{inputs.artifacts.script.path}}"

--- a/manifests/implementation/helm/storage/install.yaml
+++ b/manifests/implementation/helm/storage/install.yaml
@@ -74,16 +74,29 @@ spec:
             outputs:
               artifacts: []
             steps:
+              # Jinja2 requires an input artifact.
+              # This step makes sure it is always provided to the `create-helm-args` step,
+              # Even if user didn't provide `additional-parameters`.
+              - - name: prepare-parameters
+                  template: prepare-parameters
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        raw:
+                          data: "{}"
+                      - name: additional-parameters
+                        from: "{{inputs.artifacts.additional-parameters}}"
+                        optional: true
 
               - - name: create-helm-args
                   capact-action: jinja2.template
                   arguments:
                     artifacts:
                       - name: input-parameters
-                        from: "{{inputs.artifacts.input-parameters}}"
+                        from: "{{steps.prepare-parameters.outputs.artifacts.merged}}"
                       - name: configuration
                         raw:
-                          data:
+                          data: ""
                       - name: template
                         raw:
                           data: |
@@ -101,7 +114,7 @@ spec:
                                 targetCPUUtilizationPercentage: <@ additionalinput.autoscaling.targetCPUUtilizationPercentage | default(80) @>
                               global:
                                 containerRegistry:
-                                  overrideTag: <@ additionalinput.global.containerRegistry.overrideTag | default("latest") @>
+                                  overrideTag: <@ additionalinput.global.containerRegistry.overrideTag | default("bb9b779") @>
                                   path: <@ additionalinput.global.containerRegistry.path | default("ghcr.io/capactio") @>
                               helmReleaseBackend:
                                 enabled: <@ additionalinput.helmReleaseBackend.enabled | default(true) | tojson @>
@@ -161,9 +174,8 @@ spec:
                             cat << EOF > /tmp/helm-release
                             url: "<@ releaseSvcUrl @>"
                             acceptValue: false
-                            schema: |
-                              {
-                                "$schema": "http://json-schema.org/draft-07/schema",
+                            contextSchema: {
+                                "\$schema": "http://json-schema.org/draft-07/schema",
                                 "type": "object",
                                 "required": [
                                   "name",
@@ -172,19 +184,19 @@ spec:
                                 ],
                                 "properties": {
                                   "name": {
-                                    "$id": "#/properties/context/properties/name",
+                                    "\$id": "#/properties/context/properties/name",
                                     "type": "string"
                                   },
                                   "namespace": {
-                                    "$id": "#/properties/context/properties/namespace",
+                                    "\$id": "#/properties/context/properties/namespace",
                                     "type": "string"
                                   },
                                   "chartLocation": {
-                                    "$id": "#/properties/context/properties/chartLocation",
+                                    "\$id": "#/properties/context/properties/chartLocation",
                                     "type": "string"
                                   },
                                   "driver": {
-                                    "$id": "#/properties/context/properties/driver",
+                                    "\$id": "#/properties/context/properties/driver",
                                     "type": "string",
                                     "default": "secrets",
                                     "enum": [
@@ -201,42 +213,55 @@ spec:
                             cat << EOF > /tmp/helm-template
                             url: "<@ templateSvcUrl @>"
                             acceptValue: false
-                            schema: |
-                              {
-                                "$schema": "http://json-schema.org/draft-07/schema",
+                            contextSchema: {
+                                "\$schema": "http://json-schema.org/draft-07/schema",
                                 "type": "object",
                                 "required": [
-                                  "name",
-                                  "namespace",
-                                  "chartLocation"
+                                  "goTemplate",
+                                  "release"
                                 ],
                                 "properties": {
-                                  "name": {
-                                    "$id": "#/properties/context/properties/name",
+                                  "goTemplate": {
+                                    "\$id": "#/properties/context/properties/goTemplate",
                                     "type": "string"
                                   },
-                                  "namespace": {
-                                    "$id": "#/properties/context/properties/namespace",
-                                    "type": "string"
-                                  },
-                                  "chartLocation": {
-                                    "$id": "#/properties/context/properties/chartLocation",
-                                    "type": "string"
-                                  },
-                                  "driver": {
-                                    "$id": "#/properties/context/properties/driver",
-                                    "type": "string",
-                                    "default": "secrets",
-                                    "enum": [
-                                      "secrets",
-                                      "configmaps",
-                                      "sql"
-                                    ]
+                                  "release": {
+                                    "required": [
+                                      "name",
+                                      "namespace"
+                                    ],
+                                    "\$id": "#/properties/context/properties/release",
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                      "name": {
+                                        "\$id": "#/properties/context/properties/release/properties/name",
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "\$id": "#/properties/context/properties/release/properties/namespace",
+                                        "type": "string"
+                                      },
+                                      "driver": {
+                                        "\$id": "#/properties/context/properties/release/properties/driver",
+                                        "type": "string",
+                                        "default": "secrets",
+                                        "enum": [
+                                          "secrets",
+                                          "configmaps",
+                                          "sql"
+                                        ]
+                                      }
+                                    }
                                   }
                                 },
                                 "additionalProperties": false
                               }
                             EOF
+                            
+                            # To avoid rare "no such file or directory" errors
+                            # See also: https://github.com/argoproj/argo-workflows/issues/1256
+                            sleep 1
                       - name: input-parameters
                         from: "{{steps.helm-install.outputs.artifacts.additional}}"
                       - name: configuration
@@ -257,7 +282,6 @@ spec:
 
           - name: produce-output-tmpl
             inputs:
-              parameters:
               artifacts:
                 - name: script
                   path: /script
@@ -273,3 +297,18 @@ spec:
               command: [ sh ]
               args:
                 - "{{inputs.artifacts.script.path}}"
+
+          - name: prepare-parameters
+            inputs:
+              artifacts:
+                - name: input-parameters
+                  path: /yamls/input.yaml
+                - name: additional-parameters
+                  path: /yamls/additionalinput.yaml
+                  optional: true
+            container:
+              image: ghcr.io/capactio/pr/infra/merger:PR-428
+            outputs:
+              artifacts:
+                - name: merged
+                  path: /merged.yaml

--- a/manifests/implementation/helm/storage/install.yaml
+++ b/manifests/implementation/helm/storage/install.yaml
@@ -69,21 +69,22 @@ spec:
           - name: deploy
             inputs:
               artifacts:
+                - name: input-parameters
                 - name: additional-parameters
                   optional: true
             outputs:
-              artifacts: []
+              artifacts:
+                - name: helm-release-storage
+                  from: "{{steps.produce-output.outputs.artifacts.helm-release}}"
+                - name: helm-template-storage
+                  from: "{{steps.produce-output.outputs.artifacts.helm-template}}"
             steps:
-              # Jinja2 requires an input artifact.
-              # This step makes sure it is always provided to the `create-helm-args` step,
-              # Even if user didn't provide `additional-parameters`.
               - - name: prepare-parameters
                   template: prepare-parameters
                   arguments:
                     artifacts:
                       - name: input-parameters
-                        raw:
-                          data: "{}"
+                        from: "{{inputs.artifacts.input-parameters}}"
                       - name: additional-parameters
                         from: "{{inputs.artifacts.additional-parameters}}"
                         optional: true
@@ -104,7 +105,7 @@ spec:
                             chart:
                               name: "helm-storage-backend"
                               repo: "https://storage.googleapis.com/capactio-latest-charts"
-                              version: "0.6.0-bb9b779"
+                              version: <@ input.version | default("0.6.0-bb9b779") @>
                             values:
                               affinity: <@ additionalinput.affinity | default({}) | tojson @>
                               autoscaling:
@@ -174,7 +175,8 @@ spec:
                             cat << EOF > /tmp/helm-release
                             url: "<@ releaseSvcUrl @>"
                             acceptValue: false
-                            contextSchema: {
+                            contextSchema: |-
+                              {
                                 "\$schema": "http://json-schema.org/draft-07/schema",
                                 "type": "object",
                                 "required": [
@@ -213,7 +215,8 @@ spec:
                             cat << EOF > /tmp/helm-template
                             url: "<@ templateSvcUrl @>"
                             acceptValue: false
-                            contextSchema: {
+                            contextSchema: |-
+                              {
                                 "\$schema": "http://json-schema.org/draft-07/schema",
                                 "type": "object",
                                 "required": [

--- a/manifests/interface/helm/storage.yaml
+++ b/manifests/interface/helm/storage.yaml
@@ -1,0 +1,15 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: InterfaceGroup
+metadata:
+  prefix: "cap.interface.helm"
+  name: "storage"
+  displayName: "Helm Storage"
+  description: "Interfaces for Helm Storage"
+  documentationURL: https://capact.io/docs
+  supportURL: https://helm.sh/
+  iconURL: https://storage.googleapis.com/dashboard-icons/helm.svg
+  maintainers:
+    - email: team-dev@capact.io
+      name: Capact Dev Team
+      url: https://capact.io

--- a/manifests/interface/helm/storage/install.yaml
+++ b/manifests/interface/helm/storage/install.yaml
@@ -1,0 +1,31 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Interface
+metadata:
+  prefix: "cap.interface.helm.storage"
+  name: "install"
+  displayName: "Install"
+  description: "Installs Helm Release and Helm Template storage backends"
+  documentationURL: https://capact.io/docs
+  supportURL: https://helm.sh/
+  iconURL: https://storage.googleapis.com/dashboard-icons/helm.svg
+  maintainers:
+    - email: team-dev@capact.io
+      name: Capact Dev Team
+      url: https://capact.io
+
+spec:
+  input:
+    typeInstances: {}
+    parameters: {}
+
+  output:
+    typeInstances:
+      helm-release-storage:
+        typeRef:
+          path: cap.type.helm.release.storage
+          revision: 0.1.0
+      helm-template-storage:
+        typeRef:
+          path: cap.type.helm.template.storage
+          revision: 0.1.0

--- a/manifests/interface/helm/storage/install.yaml
+++ b/manifests/interface/helm/storage/install.yaml
@@ -17,7 +17,35 @@ metadata:
 spec:
   input:
     typeInstances: {}
-    parameters: {}
+    parameters:
+      input-parameters:
+        jsonSchema:
+          value: |-
+            {
+              "$schema": "http://json-schema.org/draft-07/schema",
+              "type": "object",
+              "definitions": {
+                  "semVer": {
+                    "type": "string",
+                    "minLength": 5,
+                    "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+                    "title": "Semantic Versioning version",
+                    "examples": [
+                      "1.19.0",
+                      "2.0.1-alpha1"
+                    ]
+                  }
+              },
+              "properties": {
+                "version": {
+                  "$id": "#/properties/version",
+                  "description": "Version",
+                  "default": "0.6.0-bb9b779",
+                  "$ref": "#/definitions/semVer"
+                }
+              },
+              "additionalProperties": false
+            }
 
   output:
     typeInstances:

--- a/manifests/type/helm/release/storage.yaml
+++ b/manifests/type/helm/release/storage.yaml
@@ -3,10 +3,10 @@ revision: 0.1.0
 kind: Type
 metadata:
   name: storage
-  prefix: cap.type.helm
-  displayName: Helm chart storage
+  prefix: cap.type.helm.release
+  displayName: Helm release chart storage
   description: Describes Helm storage
-  documentationURL: https://helm.sh/docs
+  documentationURL: https://capact.io/docs
   supportURL: https://helm.sh
   maintainers:
     - email: team-dev@capact.io

--- a/manifests/type/helm/release/storage.yaml
+++ b/manifests/type/helm/release/storage.yaml
@@ -34,40 +34,7 @@ spec:
                   "format": "uri"
               },
               "contextSchema": {
-                  "const": {
-                      "$schema": "http://json-schema.org/draft-07/schema",
-                      "type": "object",
-                      "required": [
-                          "name",
-                          "namespace",
-                          "chartLocation"
-                      ],
-                      "properties": {
-                          "name": {
-                              "$id": "#/properties/context/properties/name",
-                              "type": "string"
-                          },
-                          "namespace": {
-                              "$id": "#/properties/context/properties/namespace",
-                              "type": "string"
-                          },
-                          "chartLocation": {
-                              "$id": "#/properties/context/properties/chartLocation",
-                              "type": "string"
-                          },
-                          "driver": {
-                            "$id": "#/properties/context/properties/driver",
-                            "type": "string",
-                            "default": "secrets",
-                            "enum": [
-                              "secrets",
-                              "configmaps",
-                              "sql"
-                            ]
-                          }
-                      },
-                      "additionalProperties": false
-                  }
+                  "const": "{\n  \"$schema\": \"http://json-schema.org/draft-07/schema\",\n  \"type\": \"object\",\n  \"required\": [\n    \"name\",\n    \"namespace\",\n    \"chartLocation\"\n  ],\n  \"properties\": {\n    \"name\": {\n      \"$id\": \"#/properties/context/properties/name\",\n      \"type\": \"string\"\n    },\n    \"namespace\": {\n      \"$id\": \"#/properties/context/properties/namespace\",\n      \"type\": \"string\"\n    },\n    \"chartLocation\": {\n      \"$id\": \"#/properties/context/properties/chartLocation\",\n      \"type\": \"string\"\n    },\n    \"driver\": {\n      \"$id\": \"#/properties/context/properties/driver\",\n      \"type\": \"string\",\n      \"default\": \"secrets\",\n      \"enum\": [\n        \"secrets\",\n        \"configmaps\",\n        \"sql\"\n      ]\n    }\n  },\n  \"additionalProperties\": false\n}"
               },
               "acceptValue": {
                   "$id": "#/properties/acceptValue",

--- a/manifests/type/helm/storage/install-input.yaml
+++ b/manifests/type/helm/storage/install-input.yaml
@@ -1,0 +1,275 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Type
+metadata:
+  prefix: "cap.type.helm.storage"
+  name: install-input
+  displayName: Additional input
+  description: Additional input for Helm Release and Helm Template storage backends instllation
+  documentationURL: https://capact.io/docs
+  supportURL: https://helm.sh/
+  iconURL: https://storage.googleapis.com/dashboard-icons/helm.svg
+  maintainers:
+    - email: team-dev@capact.io
+      name: Capact Dev Team
+      url: https://capact.io
+
+spec:
+  jsonSchema:
+    value: |-
+      {
+        "properties": {
+          "affinity": {
+            "properties": {},
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Affinity",
+            "$id": "#/properties/affinity"
+          },
+          "autoscaling": {
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "title": "Enabled",
+                "default": false,
+                "$id": "#/properties/autoscaling/properties/enabled"
+              },
+              "maxReplicas": {
+                "type": "number",
+                "title": "MaxReplicas",
+                "default": 100,
+                "$id": "#/properties/autoscaling/properties/maxReplicas"
+              },
+              "minReplicas": {
+                "type": "number",
+                "title": "MinReplicas",
+                "default": 1,
+                "$id": "#/properties/autoscaling/properties/minReplicas"
+              },
+              "targetCPUUtilizationPercentage": {
+                "type": "number",
+                "title": "TargetCPUUtilizationPercentage",
+                "default": 80,
+                "$id": "#/properties/autoscaling/properties/targetCPUUtilizationPercentage"
+              }
+            },
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Autoscaling",
+            "$id": "#/properties/autoscaling"
+          },
+          "global": {
+            "properties": {
+              "containerRegistry": {
+                "properties": {
+                  "overrideTag": {
+                    "type": "string",
+                    "title": "OverrideTag",
+                    "default": "latest",
+                    "$id": "#/properties/global/properties/containerRegistry/properties/overrideTag"
+                  },
+                  "path": {
+                    "type": "string",
+                    "title": "Path",
+                    "default": "ghcr.io/capactio",
+                    "$id": "#/properties/global/properties/containerRegistry/properties/path"
+                  }
+                },
+                "additionalProperties": true,
+                "type": "object",
+                "title": "ContainerRegistry",
+                "$id": "#/properties/global/properties/containerRegistry"
+              }
+            },
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Global",
+            "$id": "#/properties/global"
+          },
+          "helmReleaseBackend": {
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "title": "Enabled",
+                "default": true,
+                "$id": "#/properties/helmReleaseBackend/properties/enabled"
+              },
+              "service": {
+                "properties": {
+                  "port": {
+                    "type": "number",
+                    "title": "Port",
+                    "default": 50051,
+                    "$id": "#/properties/helmReleaseBackend/properties/service/properties/port"
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "Type",
+                    "default": "ClusterIP",
+                    "$id": "#/properties/helmReleaseBackend/properties/service/properties/type"
+                  }
+                },
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Service",
+                "$id": "#/properties/helmReleaseBackend/properties/service"
+              }
+            },
+            "additionalProperties": true,
+            "type": "object",
+            "title": "HelmReleaseBackend",
+            "$id": "#/properties/helmReleaseBackend"
+          },
+          "helmTemplateBackend": {
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "title": "Enabled",
+                "default": true,
+                "$id": "#/properties/helmTemplateBackend/properties/enabled"
+              },
+              "service": {
+                "properties": {
+                  "port": {
+                    "type": "number",
+                    "title": "Port",
+                    "default": 50052,
+                    "$id": "#/properties/helmTemplateBackend/properties/service/properties/port"
+                  },
+                  "type": {
+                    "type": "string",
+                    "title": "Type",
+                    "default": "ClusterIP",
+                    "$id": "#/properties/helmTemplateBackend/properties/service/properties/type"
+                  }
+                },
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Service",
+                "$id": "#/properties/helmTemplateBackend/properties/service"
+              }
+            },
+            "additionalProperties": true,
+            "type": "object",
+            "title": "HelmTemplateBackend",
+            "$id": "#/properties/helmTemplateBackend"
+          },
+          "image": {
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name",
+                "default": "helm-storage-backend",
+                "$id": "#/properties/image/properties/name"
+              },
+              "pullPolicy": {
+                "type": "string",
+                "title": "PullPolicy",
+                "default": "IfNotPresent",
+                "$id": "#/properties/image/properties/pullPolicy"
+              }
+            },
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Image",
+            "$id": "#/properties/image"
+          },
+          "imagePullSecrets": {
+            "type": "array",
+            "title": "ImagePullSecrets",
+            "default": [],
+            "$id": "#/properties/imagePullSecrets"
+          },
+          "nodeSelector": {
+            "properties": {},
+            "additionalProperties": true,
+            "type": "object",
+            "title": "NodeSelector",
+            "$id": "#/properties/nodeSelector"
+          },
+          "podAnnotations": {
+            "properties": {},
+            "additionalProperties": true,
+            "type": "object",
+            "title": "PodAnnotations",
+            "$id": "#/properties/podAnnotations"
+          },
+          "podSecurityContext": {
+            "properties": {},
+            "additionalProperties": true,
+            "type": "object",
+            "title": "PodSecurityContext",
+            "$id": "#/properties/podSecurityContext"
+          },
+          "replicaCount": {
+            "type": "number",
+            "title": "ReplicaCount",
+            "default": 1,
+            "$id": "#/properties/replicaCount"
+          },
+          "resources": {
+            "properties": {
+              "limits": {
+                "properties": {
+                  "cpu": {
+                    "type": "string",
+                    "title": "Cpu",
+                    "default": "100m",
+                    "$id": "#/properties/resources/properties/limits/properties/cpu"
+                  },
+                  "memory": {
+                    "type": "string",
+                    "title": "Memory",
+                    "default": "32Mi",
+                    "$id": "#/properties/resources/properties/limits/properties/memory"
+                  }
+                },
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Limits",
+                "$id": "#/properties/resources/properties/limits"
+              },
+              "requests": {
+                "properties": {
+                  "cpu": {
+                    "type": "string",
+                    "title": "Cpu",
+                    "default": "30m",
+                    "$id": "#/properties/resources/properties/requests/properties/cpu"
+                  },
+                  "memory": {
+                    "type": "string",
+                    "title": "Memory",
+                    "default": "16Mi",
+                    "$id": "#/properties/resources/properties/requests/properties/memory"
+                  }
+                },
+                "additionalProperties": true,
+                "type": "object",
+                "title": "Requests",
+                "$id": "#/properties/resources/properties/requests"
+              }
+            },
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Resources",
+            "$id": "#/properties/resources"
+          },
+          "securityContext": {
+            "properties": {},
+            "additionalProperties": true,
+            "type": "object",
+            "title": "SecurityContext",
+            "$id": "#/properties/securityContext"
+          },
+          "tolerations": {
+            "type": "array",
+            "title": "Tolerations",
+            "default": [],
+            "$id": "#/properties/tolerations"
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "$id": "#"
+      }

--- a/manifests/type/helm/template/storage.yaml
+++ b/manifests/type/helm/template/storage.yaml
@@ -1,0 +1,89 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Type
+metadata:
+  name: storage
+  prefix: cap.type.helm.template
+  displayName: Helm template chart storage
+  description: Describes Helm storage
+  documentationURL: https://capact.io/docs
+  supportURL: https://helm.sh
+  maintainers:
+    - email: team-dev@capact.io
+      name: Capact Dev Team
+      url: https://capact.io
+
+spec:
+  additionalRefs:
+    - cap.core.type.hub.storage
+  jsonSchema:
+    value: |-
+      {
+        "$schema": "http://json-schema.org/draft-07/schema",
+        "type": "object",
+        "title": "The root schema",
+        "required": [
+          "url",
+          "contextSchema",
+          "acceptValue"
+        ],
+        "properties": {
+          "url": {
+            "$id": "#/properties/url",
+            "type": "string",
+            "format": "uri"
+          },
+          "contextSchema": {
+            "const": {
+              "$schema": "http://json-schema.org/draft-07/schema",
+              "type": "object",
+              "required": [
+                "template",
+                "release"
+              ],
+              "properties": {
+                "template": {
+                  "$id": "#/properties/context/properties/template",
+                  "type": "string"
+                },
+                "release": {
+                  "required": [
+                    "name",
+                    "namespace"
+                  ],
+                  "$id": "#/properties/context/properties/release",
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "name": {
+                      "$id": "#/properties/context/properties/release/properties/name",
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "$id": "#/properties/context/properties/release/properties/namespace",
+                      "type": "string"
+                    },
+                    "driver": {
+                      "$id": "#/properties/context/properties/release/properties/driver",
+                      "type": "string",
+                      "default": "secrets",
+                      "enum": [
+                        "secrets",
+                        "configmaps",
+                        "sql"
+                      ]
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "acceptValue": {
+            "$id": "#/properties/acceptValue",
+            "type": "boolean",
+            "const": false
+          }
+        },
+        "additionalProperties": false
+      }

--- a/manifests/type/helm/template/storage.yaml
+++ b/manifests/type/helm/template/storage.yaml
@@ -38,12 +38,12 @@ spec:
               "$schema": "http://json-schema.org/draft-07/schema",
               "type": "object",
               "required": [
-                "template",
+                "goTemplate",
                 "release"
               ],
               "properties": {
-                "template": {
-                  "$id": "#/properties/context/properties/template",
+                "goTemplate": {
+                  "$id": "#/properties/context/properties/goTemplate",
                   "type": "string"
                 },
                 "release": {

--- a/manifests/type/helm/template/storage.yaml
+++ b/manifests/type/helm/template/storage.yaml
@@ -5,7 +5,7 @@ metadata:
   name: storage
   prefix: cap.type.helm.template
   displayName: Helm template chart storage
-  description: Describes Helm storage
+  description: Describes Helm template storage
   documentationURL: https://capact.io/docs
   supportURL: https://helm.sh
   maintainers:
@@ -17,6 +17,7 @@ spec:
   additionalRefs:
     - cap.core.type.hub.storage
   jsonSchema:
+    # TODO: Change globally `contextSchema` to object
     value: |-
       {
         "$schema": "http://json-schema.org/draft-07/schema",
@@ -34,50 +35,7 @@ spec:
             "format": "uri"
           },
           "contextSchema": {
-            "const": {
-              "$schema": "http://json-schema.org/draft-07/schema",
-              "type": "object",
-              "required": [
-                "goTemplate",
-                "release"
-              ],
-              "properties": {
-                "goTemplate": {
-                  "$id": "#/properties/context/properties/goTemplate",
-                  "type": "string"
-                },
-                "release": {
-                  "required": [
-                    "name",
-                    "namespace"
-                  ],
-                  "$id": "#/properties/context/properties/release",
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "name": {
-                      "$id": "#/properties/context/properties/release/properties/name",
-                      "type": "string"
-                    },
-                    "namespace": {
-                      "$id": "#/properties/context/properties/release/properties/namespace",
-                      "type": "string"
-                    },
-                    "driver": {
-                      "$id": "#/properties/context/properties/release/properties/driver",
-                      "type": "string",
-                      "default": "secrets",
-                      "enum": [
-                        "secrets",
-                        "configmaps",
-                        "sql"
-                      ]
-                    }
-                  }
-                }
-              },
-              "additionalProperties": false
-            }
+            "const": "{\n  \"$schema\": \"http://json-schema.org/draft-07/schema\",\n  \"type\": \"object\",\n  \"required\": [\n    \"goTemplate\",\n    \"release\"\n  ],\n  \"properties\": {\n    \"goTemplate\": {\n      \"$id\": \"#/properties/context/properties/goTemplate\",\n      \"type\": \"string\"\n    },\n    \"release\": {\n      \"required\": [\n        \"name\",\n        \"namespace\"\n      ],\n      \"$id\": \"#/properties/context/properties/release\",\n      \"type\": \"object\",\n      \"additionalProperties\": false,\n      \"properties\": {\n        \"name\": {\n          \"$id\": \"#/properties/context/properties/release/properties/name\",\n          \"type\": \"string\"\n        },\n        \"namespace\": {\n          \"$id\": \"#/properties/context/properties/release/properties/namespace\",\n          \"type\": \"string\"\n        },\n        \"driver\": {\n          \"$id\": \"#/properties/context/properties/release/properties/driver\",\n          \"type\": \"string\",\n          \"default\": \"secrets\",\n          \"enum\": [\n            \"secrets\",\n            \"configmaps\",\n            \"sql\"\n          ]\n        }\n      }\n    }\n  },\n  \"additionalProperties\": false\n}"
           },
           "acceptValue": {
             "$id": "#/properties/acceptValue",


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Introduce Helm storage backends installation manifests

## Notes

This PR bases on #62, however it assumes the path of the Type manifest is different.

## Testing

### Option A: UI

1. Navigate to the UI, select Helm Storage installation and create Action from it. Run it and wait for output.
2. Repeat the same steps, but with "Advanced configuratiom" - modify additionalInput and run the Action.

### Option B: CLI

#### Prerequisites

1. Checkout this branch.
2. Run Capact
3. Set manifest location to my fork

```bash
kubectl set env deploy/capact-hub-public -n capact-system -c hub-public-populator MANIFESTS_SOURCES="github.com/pkosiec/hub-manifests?ref=helm-storage-manifests"
```

4. Wait until the manifests are populated

#### Create & run Action

1. Create Parameters:

   ```bash
   cat > /tmp/helm-storage-input-params.yaml << ENDOFFILE
   input-parameters: {}
   ENDOFFILE
   ```

1. Create Action:
   ```bash
   capact act create cap.interface.helm.storage.install --name helm-storage -n capact-system --parameters-from-file /tmp/helm-storage-input-params.yaml
   ```

1. Wait for the Action to have the `READY_TO_RUN` status:

   ```bash
   capact act get helm-storage -n capact-system
   ```

1. Run Action:

   ```bash
   capact act run helm-storage -n capact-system
   ```

1. Watch the Action for completion:

    ```bash
    capact act watch helm-storage -n capact-system
    ```

1. Get output TypeInstances:

    ```bash
    capact act get helm-storage -n capact-system -ojson | jq '.Actions[0].output.typeInstances'
    ```

    See the details of the installed Helm release backend:

     ```bash
     HELM_RELEASE_STORAGE_ID=$(capact act get helm-storage -n capact-system -ojson | jq '.Actions[0].output.typeInstances | map(select(.typeRef.path == "cap.type.helm.release.storage"))[0].id' -r)
     capact ti get $HELM_RELEASE_STORAGE_ID -oyaml
     ```

    See the details of the installed Helm template backend:

     ```bash
     HELM_TEMPLATE_STORAGE_ID=$(capact act get helm-storage -n capact-system -ojson | jq '.Actions[0].output.typeInstances | map(select(.typeRef.path == "cap.type.helm.template.storage"))[0].id' -r)
     capact ti get $HELM_TEMPLATE_STORAGE_ID -oyaml
     ```

You can also run this Action with Action policy to set up additional Parameters.  For example, you can pass the following Action Policy:

```yaml
interface:
  rules:
    - interface:
        path: cap.interface.helm.storage.install
      oneOf:
        - implementationConstraints:
            path: cap.implementation.helm.storage.install
          inject:
            additionalParameters:
              - name: additional-parameters
                value:
                  affinity: {}
                  autoscaling:
                    enabled: false
                    maxReplicas: 100
                    minReplicas: 1
                    targetCPUUtilizationPercentage: 80
                  global:
                    containerRegistry:
                      overrideTag: bb9b779
                      path: ghcr.io/capactio
                  helmReleaseBackend:
                    enabled: true
                    service:
                      port: 50051
                      type: ClusterIP
                  helmTemplateBackend:
                    enabled: true
                    service:
                      port: 50052
                      type: ClusterIP
                  image:
                    name: helm-storage-backend
                    pullPolicy: IfNotPresent
                  imagePullSecrets: []
                  nodeSelector: {}
                  podAnnotations: {}
                  podSecurityContext: {}
                  replicaCount: 1
                  resources:
                    limits:
                      cpu: 200m
                      memory: 64Mi <- Updated value
                    requests:
                      cpu: 30m
                      memory: 16Mi
                  securityContext: {}
                  tolerations: []
    - interface:
        path: cap.*
      oneOf:
        - implementationConstraints:
            requires:
              - path: cap.core.type.platform.kubernetes
```

But, the easiest way is to do it from UI 🙂 

## Related issue(s)

Resolves https://github.com/capactio/capact/issues/670
