### PR TITLE
Use Helm storage in Mattermost installation manifests

### DIFF
--- a/manifests/implementation/bitnami/postgresql/install.yaml
+++ b/manifests/implementation/bitnami/postgresql/install.yaml
@@ -46,6 +46,14 @@ spec:
       oneOf:
         - name: kubernetes
           revision: 0.1.0
+    cap.core.type.hub.storage:
+      allOf:
+        - name: cap.type.helm.release.storage
+          revision: 0.1.0
+          alias: helm-release-storage
+        - name: cap.type.helm.template.storage
+          revision: 0.1.0
+          alias: helm-template-storage
 
   imports:
     - interfaceGroupPath: cap.interface.runner.helm
@@ -103,25 +111,31 @@ spec:
                                   postgresqlDatabase: <@ defaultDBName | default('postgres') @>
                                   postgresqlPassword: <@ superuser.password | default(random_word(length=16)) @>
                             output:
-                              goTemplate: |
-                                host: '{{ template "common.names.fullname" . }}.{{ .Release.Namespace }}'
-                                port: {{ template "postgresql.port" . }}
-                                defaultDBName: '{{ template "postgresql.database" . }}'
-                                superuser:
-                                  # It cannot be changed
-                                  username: 'postgres'
-                                  password: '{{ template "postgresql.password" . }}'
+                              helmRelease:
+                                useHelmReleaseStorage: true
+                              additional:
+                                useHelmTemplateStorage: false # TODO: Toggle to true and make sure it can be reused in umbrella workflows
+                                goTemplate: |
+                                  host: '{{ template "common.names.fullname" . }}.{{ .Release.Namespace }}'
+                                  port: {{ template "postgresql.port" . }}
+                                  defaultDBName: '{{ template "postgresql.database" . }}'
+                                  superuser:
+                                    # It cannot be changed
+                                    username: 'postgres'
+                                    password: '{{ template "postgresql.password" . }}'
                       - name: configuration
                         raw:
-                          data: |
+                          data: "unpackValue: true"
 
               - - name: helm-install
                   capact-action: helm.install
                   capact-outputTypeInstances: # Defines which artifacts are output TypeInstances
                     - name: postgresql
                       from: additional
+                      backend: helm-template-storage
                     - name: psql-helm-release
                       from: helm-release
+                      backend: helm-release-storage
                   arguments:
                     artifacts:
                       - name: input-parameters

--- a/manifests/implementation/bitnami/postgresql/install.yaml
+++ b/manifests/implementation/bitnami/postgresql/install.yaml
@@ -51,9 +51,10 @@ spec:
         - name: cap.type.helm.release.storage
           revision: 0.1.0
           alias: helm-release-storage
-        - name: cap.type.helm.template.storage
-          revision: 0.1.0
-          alias: helm-template-storage
+# TODO: Uncomment once dynamic TypeInstances are supported in umbrella workflow
+#        - name: cap.type.helm.template.storage
+#          revision: 0.1.0
+#          alias: helm-template-storage
 
   imports:
     - interfaceGroupPath: cap.interface.runner.helm

--- a/manifests/implementation/helm/storage/install.yaml
+++ b/manifests/implementation/helm/storage/install.yaml
@@ -145,9 +145,13 @@ spec:
                               securityContext: <@ additionalinput.securityContext | default({}) | tojson @>
                               tolerations: <@ additionalinput.tolerations | default([]) | tojson @>
                             output:
-                              goTemplate: |
-                                releaseSvcUrl: '{{ include "helm-storage-backend.fullname" . }}-release.{{ .Release.Namespace }}:{{ .Values.helmReleaseBackend.service.port }}'
-                                templateSvcUrl: '{{ include "helm-storage-backend.fullname" . }}-template.{{ .Release.Namespace }}:{{ .Values.helmTemplateBackend.service.port }}'
+                              helmRelease:
+                                useHelmReleaseStorage: false
+                              additional:
+                                useHelmTemplateStorage: false  
+                                goTemplate: |
+                                  releaseSvcUrl: '{{ include "helm-storage-backend.fullname" . }}-release.{{ .Release.Namespace }}:{{ .Values.helmReleaseBackend.service.port }}'
+                                  templateSvcUrl: '{{ include "helm-storage-backend.fullname" . }}-template.{{ .Release.Namespace }}:{{ .Values.helmTemplateBackend.service.port }}'
 
               - - name: helm-install
                   capact-action: helm.install
@@ -173,93 +177,95 @@ spec:
                             set -e
                             
                             cat << EOF > /tmp/helm-release
-                            url: "<@ releaseSvcUrl @>"
-                            acceptValue: false
-                            contextSchema: |-
-                              {
-                                "\$schema": "http://json-schema.org/draft-07/schema",
-                                "type": "object",
-                                "required": [
-                                  "name",
-                                  "namespace",
-                                  "chartLocation"
-                                ],
-                                "properties": {
-                                  "name": {
-                                    "\$id": "#/properties/context/properties/name",
-                                    "type": "string"
+                            value:
+                              url: "<@ releaseSvcUrl @>"
+                              acceptValue: false
+                              contextSchema: |-
+                                {
+                                  "\$schema": "http://json-schema.org/draft-07/schema",
+                                  "type": "object",
+                                  "required": [
+                                    "name",
+                                    "namespace",
+                                    "chartLocation"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "\$id": "#/properties/context/properties/name",
+                                      "type": "string"
+                                    },
+                                    "namespace": {
+                                      "\$id": "#/properties/context/properties/namespace",
+                                      "type": "string"
+                                    },
+                                    "chartLocation": {
+                                      "\$id": "#/properties/context/properties/chartLocation",
+                                      "type": "string"
+                                    },
+                                    "driver": {
+                                      "\$id": "#/properties/context/properties/driver",
+                                      "type": "string",
+                                      "default": "secrets",
+                                      "enum": [
+                                        "secrets",
+                                        "configmaps",
+                                        "sql"
+                                      ]
+                                    }
                                   },
-                                  "namespace": {
-                                    "\$id": "#/properties/context/properties/namespace",
-                                    "type": "string"
-                                  },
-                                  "chartLocation": {
-                                    "\$id": "#/properties/context/properties/chartLocation",
-                                    "type": "string"
-                                  },
-                                  "driver": {
-                                    "\$id": "#/properties/context/properties/driver",
-                                    "type": "string",
-                                    "default": "secrets",
-                                    "enum": [
-                                      "secrets",
-                                      "configmaps",
-                                      "sql"
-                                    ]
-                                  }
-                                },
-                                "additionalProperties": false
-                              }
+                                  "additionalProperties": false
+                                }
                             EOF
                             
                             cat << EOF > /tmp/helm-template
-                            url: "<@ templateSvcUrl @>"
-                            acceptValue: false
-                            contextSchema: |-
-                              {
-                                "\$schema": "http://json-schema.org/draft-07/schema",
-                                "type": "object",
-                                "required": [
-                                  "goTemplate",
-                                  "release"
-                                ],
-                                "properties": {
-                                  "goTemplate": {
-                                    "\$id": "#/properties/context/properties/goTemplate",
-                                    "type": "string"
-                                  },
-                                  "release": {
-                                    "required": [
-                                      "name",
-                                      "namespace"
-                                    ],
-                                    "\$id": "#/properties/context/properties/release",
-                                    "type": "object",
-                                    "additionalProperties": false,
-                                    "properties": {
-                                      "name": {
-                                        "\$id": "#/properties/context/properties/release/properties/name",
-                                        "type": "string"
-                                      },
-                                      "namespace": {
-                                        "\$id": "#/properties/context/properties/release/properties/namespace",
-                                        "type": "string"
-                                      },
-                                      "driver": {
-                                        "\$id": "#/properties/context/properties/release/properties/driver",
-                                        "type": "string",
-                                        "default": "secrets",
-                                        "enum": [
-                                          "secrets",
-                                          "configmaps",
-                                          "sql"
-                                        ]
+                            value:
+                              url: "<@ templateSvcUrl @>"
+                              acceptValue: false
+                              contextSchema: |-
+                                {
+                                  "\$schema": "http://json-schema.org/draft-07/schema",
+                                  "type": "object",
+                                  "required": [
+                                    "goTemplate",
+                                    "release"
+                                  ],
+                                  "properties": {
+                                    "goTemplate": {
+                                      "\$id": "#/properties/context/properties/goTemplate",
+                                      "type": "string"
+                                    },
+                                    "release": {
+                                      "required": [
+                                        "name",
+                                        "namespace"
+                                      ],
+                                      "\$id": "#/properties/context/properties/release",
+                                      "type": "object",
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "name": {
+                                          "\$id": "#/properties/context/properties/release/properties/name",
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "\$id": "#/properties/context/properties/release/properties/namespace",
+                                          "type": "string"
+                                        },
+                                        "driver": {
+                                          "\$id": "#/properties/context/properties/release/properties/driver",
+                                          "type": "string",
+                                          "default": "secrets",
+                                          "enum": [
+                                            "secrets",
+                                            "configmaps",
+                                            "sql"
+                                          ]
+                                        }
                                       }
                                     }
-                                  }
-                                },
-                                "additionalProperties": false
-                              }
+                                  },
+                                  "additionalProperties": false
+                                }
                             EOF
                             
                             # To avoid rare "no such file or directory" errors
@@ -310,7 +316,7 @@ spec:
                   path: /yamls/additionalinput.yaml
                   optional: true
             container:
-              image: ghcr.io/capactio/pr/infra/merger:PR-428
+              image: ghcr.io/capactio/pr/infra/merger:PR-657
             outputs:
               artifacts:
                 - name: merged

--- a/manifests/implementation/helm/storage/install.yaml
+++ b/manifests/implementation/helm/storage/install.yaml
@@ -105,7 +105,7 @@ spec:
                             chart:
                               name: "helm-storage-backend"
                               repo: "https://storage.googleapis.com/capactio-latest-charts"
-                              version: <@ input.version | default("0.6.0-bb9b779") @>
+                              version: <@ input.version | default("0.6.0-bf8d006") @>
                             values:
                               affinity: <@ additionalinput.affinity | default({}) | tojson @>
                               autoscaling:
@@ -115,7 +115,7 @@ spec:
                                 targetCPUUtilizationPercentage: <@ additionalinput.autoscaling.targetCPUUtilizationPercentage | default(80) @>
                               global:
                                 containerRegistry:
-                                  overrideTag: <@ additionalinput.global.containerRegistry.overrideTag | default("bb9b779") @>
+                                  overrideTag: <@ additionalinput.global.containerRegistry.overrideTag | default("bf8d006") @>
                                   path: <@ additionalinput.global.containerRegistry.path | default("ghcr.io/capactio") @>
                               helmReleaseBackend:
                                 enabled: <@ additionalinput.helmReleaseBackend.enabled | default(true) | tojson @>

--- a/manifests/implementation/mattermost/mattermost-team-edition/install.yaml
+++ b/manifests/implementation/mattermost/mattermost-team-edition/install.yaml
@@ -118,7 +118,7 @@ spec:
                               username: superuser
                             defaultDBName: postgres
 
-              # TODO: Make PostgreSQL TypeInstance dynamic and ensure
+              # TODO: Make PostgreSQL config TypeInstance dynamic and ensure it can be used in umbrella workflow
 
               - - name: create-user
                   capact-action: postgresql.create-user

--- a/manifests/implementation/mattermost/mattermost-team-edition/install.yaml
+++ b/manifests/implementation/mattermost/mattermost-team-edition/install.yaml
@@ -48,6 +48,14 @@ spec:
       oneOf:
         - name: kubernetes
           revision: 0.1.0
+    cap.core.type.hub.storage:
+      allOf:
+        - name: cap.type.helm.release.storage
+          revision: 0.1.0
+          alias: helm-release-storage
+        - name: cap.type.helm.template.storage
+          revision: 0.1.0
+          alias: helm-template-storage
 
   imports:
     - interfaceGroupPath: cap.interface.runner.helm
@@ -109,6 +117,8 @@ spec:
                             superuser:
                               username: superuser
                             defaultDBName: postgres
+
+              # TODO: Make PostgreSQL TypeInstance dynamic and ensure
 
               - - name: create-user
                   capact-action: postgresql.create-user
@@ -440,22 +450,28 @@ spec:
                                   Plugins: <@ input.configJSON.PluginSettings.Plugins | default({}) @>
                                   PluginStates: <@ input.configJSON.PluginSettings.PluginStates | default({}) @>
                             output:
-                              goTemplate: |
-                                host: "{{ index .Values.ingress.hosts 0 }}"
-                                version: "{{ .Values.image.tag }}"
+                              helmRelease:
+                                useHelmReleaseStorage: true
+                              additional:
+                                useHelmTemplateStorage: true  
+                                goTemplate: |
+                                  host: "{{ index .Values.ingress.hosts 0 }}"
+                                  version: "{{ .Values.image.tag }}"
                       - name: input-parameters
                         from: "{{steps.prepare-parameters.outputs.artifacts.merged}}"
                       - name: configuration
                         raw:
-                          data: |
+                          data: "unpackValue: true"
 
               - - name: helm-install
                   capact-action: helm.install
                   capact-outputTypeInstances:
                     - name: mattermost-config
                       from: additional
+                      backend: helm-template-storage
                     - name: mattermost-helm-release
                       from: helm-release
+                      backend: helm-release-storage
                   arguments:
                     artifacts:
                       - name: input-parameters

--- a/manifests/implementation/postgresql/create-user.yaml
+++ b/manifests/implementation/postgresql/create-user.yaml
@@ -76,8 +76,9 @@ spec:
 
 
                             cat <<EOF > /user.yaml
-                            name: <@ input.name @>
-                            password: <@ password @>
+                            value:
+                              name: <@ input.name @>
+                              password: <@ password @>
                             EOF
                             sync
                       - name: input-parameters

--- a/manifests/implementation/runner/helm/install.yaml
+++ b/manifests/implementation/runner/helm/install.yaml
@@ -78,7 +78,7 @@ spec:
               - name: tmp
                 emptyDir: { }
             container:
-              image: ghcr.io/capactio/pr/helm-runner:PR-657
+              image: ghcr.io/capactio/pr/helm-runner:PR-686
               env:
                 - name: RUNNER_OPTIONAL_KUBECONFIG_TI
                   value: "{{inputs.artifacts.kubeconfig.path}}"

--- a/manifests/implementation/runner/helm/upgrade.yaml
+++ b/manifests/implementation/runner/helm/upgrade.yaml
@@ -94,7 +94,7 @@ spec:
                   path: "/additional.yaml"
                   optional: true
             container:
-              image: ghcr.io/capactio/pr/helm-runner:PR-657
+              image: ghcr.io/capactio/pr/helm-runner:PR-686
               env:
                 - name: RUNNER_CONTEXT_PATH
                   value: "{{inputs.artifacts.runner-context.path}}"

--- a/manifests/interface/helm/storage/install.yaml
+++ b/manifests/interface/helm/storage/install.yaml
@@ -40,7 +40,7 @@ spec:
                 "version": {
                   "$id": "#/properties/version",
                   "description": "Version",
-                  "default": "0.6.0-bb9b779",
+                  "default": "0.6.0-bf8d006",
                   "$ref": "#/definitions/semVer"
                 }
               },

--- a/manifests/type/helm/storage/install-input.yaml
+++ b/manifests/type/helm/storage/install-input.yaml
@@ -65,7 +65,7 @@ spec:
                   "overrideTag": {
                     "type": "string",
                     "title": "OverrideTag",
-                    "default": "latest",
+                    "default": "bf8d006",
                     "$id": "#/properties/global/properties/containerRegistry/properties/overrideTag"
                   },
                   "path": {

--- a/manifests/type/runner/helm/install-input.yaml
+++ b/manifests/type/runner/helm/install-input.yaml
@@ -34,13 +34,19 @@ spec:
               "postgresqlPassword": "s3cr3t"
             },
             "output": {
-              "goTemplate": {
-                "host": "{{ template \"postgresql.primary.fullname\" . }}",
-                "port": "{{ template \"postgresql.port\" . }}",
-                "defaultDBName": "{{ template \"postgresql.database\" . }}",
-                "superuser": {
-                  "username": "{{ template \"postgresql.username\" . }}",
-                  "password": "{{ template \"postgresql.password\" . }}"
+              "helmRelease": {
+                "useHelmReleaseStorage": true
+              },
+              "additional": {
+                "useHelmTemplateStorage": true,
+                "goTemplate": {
+                  "host": "{{ template \"postgresql.primary.fullname\" . }}",
+                  "port": "{{ template \"postgresql.port\" . }}",
+                  "defaultDBName": "{{ template \"postgresql.database\" . }}",
+                  "superuser": {
+                    "username": "{{ template \"postgresql.username\" . }}",
+                    "password": "{{ template \"postgresql.password\" . }}"
+                  }
                 }
               }
             }
@@ -114,21 +120,46 @@ spec:
             "title": "The path for file with values for chart"
           },
           "output": {
-            "$id": "#/properties/output",
-            "type": "object",
-            "title": "The parameters for output files",
-            "additionalProperties": false,
-            "required": [
-              "goTemplate"
-            ],
             "properties": {
-              "goTemplate": {
-                "$id": "#/properties/output/properties/goTemplate",
+              "helmRelease": {
+                "$id": "#/properties/output/properties/helmRelease",
                 "type": "object",
-                "title": "Defines additional data to extract from Helm release and save as additional output. Support Go template syntax.",
-                "additionalProperties": true
+                "title": "The parameters for Helm Release output",
+                "additionalProperties": false,
+                "properties": {
+                  "useHelmReleaseStorage": {
+                    "$id": "#/properties/output/properties/helmRelease/properties/useHelmReleaseStorage",
+                    "type": "boolean",
+                    "title": "Specifies whether to use Helm Release storage",
+                    "default": false
+                  }
+                }
+              },
+              "additional": {
+                "$id": "#/properties/output/properties/additional",
+                "type": "object",
+                "title": "The parameters for additional output",
+                "required": [
+                  "goTemplate"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "useHelmTemplateStorage": {
+                    "$id": "#/properties/output/properties/additional/properties/useHelmTemplateStorage",
+                    "type": "boolean",
+                    "title": "Specifies whether to use Helm Template storage",
+                    "default": false
+                  },
+                  "goTemplate": {
+                    "$id": "#/properties/output/properties/goTemplate",
+                    "type": "object",
+                    "title": "Defines additional data to extract from Helm release and save as additional output. Support Go template syntax.",
+                    "additionalProperties": true
+                  }
+                }
               }
             }
           }
         }
       }
+      

--- a/manifests/type/runner/helm/install-input.yaml
+++ b/manifests/type/runner/helm/install-input.yaml
@@ -120,7 +120,17 @@ spec:
             "title": "The path for file with values for chart"
           },
           "output": {
+            "$id": "#/properties/output",
+            "type": "object",
+            "title": "The parameters for outputs",
+            "additionalProperties": false,
             "properties": {
+              "goTemplate": {
+                "$id": "#/properties/output/properties/goTemplate",
+                "type": "string",
+                "title": "Deprecated: Use additional.goTemplate instead. Defines additional data to extract from Helm release and save as additional output. Support Go template syntax.",
+                "additionalProperties": true
+              },
               "helmRelease": {
                 "$id": "#/properties/output/properties/helmRelease",
                 "type": "object",
@@ -151,8 +161,8 @@ spec:
                     "default": false
                   },
                   "goTemplate": {
-                    "$id": "#/properties/output/properties/goTemplate",
-                    "type": "object",
+                    "$id": "#/properties/output/properties/additional/properties/goTemplate",
+                    "type": "string",
                     "title": "Defines additional data to extract from Helm release and save as additional output. Support Go template syntax.",
                     "additionalProperties": true
                   }

--- a/manifests/type/runner/helm/upgrade-input.yaml
+++ b/manifests/type/runner/helm/upgrade-input.yaml
@@ -125,7 +125,17 @@ spec:
             "title": "The path for file with values for chart"
           },
           "output": {
+            "$id": "#/properties/output",
+            "type": "object",
+            "title": "The parameters for outputs",
+            "additionalProperties": false,
             "properties": {
+              "goTemplate": {
+                "$id": "#/properties/output/properties/goTemplate",
+                "type": "string",
+                "title": "Deprecated: Use additional.goTemplate instead. Defines additional data to extract from Helm release and save as additional output. Support Go template syntax.",
+                "additionalProperties": true
+              },
               "helmRelease": {
                 "$id": "#/properties/output/properties/helmRelease",
                 "type": "object",
@@ -156,8 +166,8 @@ spec:
                     "default": false
                   },
                   "goTemplate": {
-                    "$id": "#/properties/output/properties/goTemplate",
-                    "type": "object",
+                    "$id": "#/properties/output/properties/additional/properties/goTemplate",
+                    "type": "string",
                     "title": "Defines additional data to extract from Helm release and save as additional output. Support Go template syntax.",
                     "additionalProperties": true
                   }

--- a/manifests/type/runner/helm/upgrade-input.yaml
+++ b/manifests/type/runner/helm/upgrade-input.yaml
@@ -36,13 +36,19 @@ spec:
               "postgresqlPassword": "s3cr3t"
             },
             "output": {
-              "goTemplate": {
-                "host": "{{ template \"postgresql.primary.fullname\" . }}",
-                "port": "{{ template \"postgresql.port\" . }}",
-                "defaultDBName": "{{ template \"postgresql.database\" . }}",
-                "superuser": {
-                  "username": "{{ template \"postgresql.username\" . }}",
-                  "password": "{{ template \"postgresql.password\" . }}"
+              "helmRelease": {
+                "useHelmReleaseStorage": true
+              },
+              "additional": {
+                "useHelmTemplateStorage": true,
+                "goTemplate": {
+                  "host": "{{ template \"postgresql.primary.fullname\" . }}",
+                  "port": "{{ template \"postgresql.port\" . }}",
+                  "defaultDBName": "{{ template \"postgresql.database\" . }}",
+                  "superuser": {
+                    "username": "{{ template \"postgresql.username\" . }}",
+                    "password": "{{ template \"postgresql.password\" . }}"
+                  }
                 }
               }
             }
@@ -51,89 +57,113 @@ spec:
         "additionalProperties": false,
         "required": [],
         "properties": {
-            "chart": {
-              "$id": "#/properties/chart",
-              "type": "object",
-              "title": "The chart data. If not provided, the ones from existing Helm Release are used.",
-              "required": [],
-              "properties": {
-                "name": {
-                  "$id": "#/properties/chart/properties/name",
-                  "type": "string",
-                  "title": "The name of Chart",
-                  "default": ""
-                },
-                "version": {
-                  "$id": "#/properties/chart/properties/version",
-                  "type": "string",
-                  "title": "Specify the exact chart version to use. If this is not specified, the latest version is used",
-                  "default": ""
-                },
-                "repo": {
-                  "$id": "#/properties/repo",
-                  "type": "string",
-                  "title": "Chart repository URL where to locate the requested chart"
+          "chart": {
+            "$id": "#/properties/chart",
+            "type": "object",
+            "title": "The chart data. If not provided, the ones from existing Helm Release are used.",
+            "required": [],
+            "properties": {
+              "name": {
+                "$id": "#/properties/chart/properties/name",
+                "type": "string",
+                "title": "The name of Chart",
+                "default": ""
+              },
+              "version": {
+                "$id": "#/properties/chart/properties/version",
+                "type": "string",
+                "title": "Specify the exact chart version to use. If this is not specified, the latest version is used",
+                "default": ""
+              },
+              "repo": {
+                "$id": "#/properties/repo",
+                "type": "string",
+                "title": "Chart repository URL where to locate the requested chart"
+              }
+            },
+            "additionalProperties": false
+          },
+          "noHooks": {
+            "$id": "#/properties/noHooks",
+            "type": "boolean",
+            "title": "Prevent hooks from running during install",
+            "default": false
+          },
+          "reuseValues": {
+            "$id": "#/properties/reuseValues",
+            "type": "boolean",
+            "title": "Reuses the last release's values and merge in any overrides during upgrade",
+            "default": false
+          },
+          "resetValues": {
+            "$id": "#/properties/resetValues",
+            "type": "boolean",
+            "title": "Resets the values to the ones built into the chart during upgrade",
+            "default": false
+          },
+          "maxHistory": {
+            "$id": "#/properties/maxHistory",
+            "type": "integer",
+            "title": "Limits the maximum number of revisions saved per release.",
+            "default": 10
+          },
+          "replace": {
+            "$id": "#/properties/replace",
+            "type": "boolean",
+            "title": "Re-use the given name, only if that name is a deleted release which remains in the history. This is unsafe in production",
+            "default": false
+          },
+          "values": {
+            "$id": "#/properties/values",
+            "type": "object",
+            "title": "The values for chart",
+            "additionalProperties": true
+          },
+          "valuesFromFile": {
+            "$id": "#/properties/valuesFromFile",
+            "type": "string",
+            "title": "The path for file with values for chart"
+          },
+          "output": {
+            "properties": {
+              "helmRelease": {
+                "$id": "#/properties/output/properties/helmRelease",
+                "type": "object",
+                "title": "The parameters for Helm Release output",
+                "additionalProperties": false,
+                "properties": {
+                  "useHelmReleaseStorage": {
+                    "$id": "#/properties/output/properties/helmRelease/properties/useHelmReleaseStorage",
+                    "type": "boolean",
+                    "title": "Specifies whether to use Helm Release storage",
+                    "default": false
+                  }
                 }
               },
-              "additionalProperties": false
-            },
-            "noHooks": {
-              "$id": "#/properties/noHooks",
-              "type": "boolean",
-              "title": "Prevent hooks from running during install",
-              "default": false
-            },
-            "reuseValues": {
-              "$id": "#/properties/reuseValues",
-              "type": "boolean",
-              "title": "Reuses the last release's values and merge in any overrides during upgrade",
-              "default": false
-            },
-            "resetValues": {
-               "$id": "#/properties/resetValues",
-               "type": "boolean",
-               "title": "Resets the values to the ones built into the chart during upgrade",
-               "default": false
-             },
-            "maxHistory": {
-               "$id": "#/properties/maxHistory",
-               "type": "integer",
-               "title": "Limits the maximum number of revisions saved per release.",
-               "default": 10
-             },
-            "replace": {
-              "$id": "#/properties/replace",
-              "type": "boolean",
-              "title": "Re-use the given name, only if that name is a deleted release which remains in the history. This is unsafe in production",
-              "default": false
-            },
-            "values": {
-              "$id": "#/properties/values",
-              "type": "object",
-              "title": "The values for chart",
-              "additionalProperties": true
-            },
-            "valuesFromFile": {
-              "$id": "#/properties/valuesFromFile",
-              "type": "string",
-              "title": "The path for file with values for chart"
-            },
-            "output": {
-              "$id": "#/properties/output",
-              "type": "object",
-              "title": "The parameters for output files",
-              "additionalProperties": false,
-              "required": [
-                "goTemplate"
-              ],
-              "properties": {
-                "goTemplate": {
-                  "$id": "#/properties/output/properties/goTemplate",
-                  "type": "object",
-                  "title": "Defines additional data to extract from Helm release and save as additional output. Support Go template syntax.",
-                  "additionalProperties": true
+              "additional": {
+                "$id": "#/properties/output/properties/additional",
+                "type": "object",
+                "title": "The parameters for additional output",
+                "required": [
+                  "goTemplate"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "useHelmTemplateStorage": {
+                    "$id": "#/properties/output/properties/additional/properties/useHelmTemplateStorage",
+                    "type": "boolean",
+                    "title": "Specifies whether to use Helm Template storage",
+                    "default": false
+                  },
+                  "goTemplate": {
+                    "$id": "#/properties/output/properties/goTemplate",
+                    "type": "object",
+                    "title": "Defines additional data to extract from Helm release and save as additional output. Support Go template syntax.",
+                    "additionalProperties": true
+                  }
                 }
               }
             }
+          }
         }
       }


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Use Helm storage in Mattermost installation manifests
- Update Helm runner manifests (Helm release + Helm template storages are disabled by default)

## Testing

1. Run cluster from the https://github.com/capactio/capact/pull/686 (`DISABLE_MONITORING_INSTALLATION=true USE_TEST_SETUP=true make dev-cluster`)
1. Set manifests from my fork:
```bash
kubectl set env deploy/capact-hub-public -n capact-system -c hub-public-populator MANIFESTS_SOURCES="github.com/pkosiec/hub-manifests?ref=use-helm-storage"
```
1. Install Helm Storage Backends via Dashboard
1. Update Global Policy:

```bash
HELM_TEMPLATE_STORAGE_ID="0406ffe8-5f2b-43ae-bdc5-56bb7e09d1b8"
HELM_RELEASE_STORAGE_ID="1147087a-e7d3-4d46-a653-8af8c07ef2bd"

cat > /tmp/helm-storage-policy.yaml << ENDOFFILE
interface:
  default: # properties applied to all rules above
     inject:
       requiredTypeInstances:
          - id: ${HELM_TEMPLATE_STORAGE_ID}
            description: "Helm template"
          - id: ${HELM_RELEASE_STORAGE_ID}
            description: "Helm release"
  rules:
      - interface:
          path: cap.*
        oneOf:
        - implementationConstraints:
            requires:
            - path: cap.core.type.platform.kubernetes
        - implementationConstraints: {}

ENDOFFILE
capact policy apply -f /tmp/helm-storage-policy.yaml
```
1. Update Helm Storage Backend images to: `ghcr.io/capactio/pr/helm-storage-backend:PR-685` - **WARNING:** Do it for both of the containers from the deployment!
1. Run Mattermost installation

## Related issue(s)

https://github.com/capactio/capact/issues/673
