### PR TITLE
Use Helm template storage backend for PostgreSQL and Mattermost installation

### DIFF
--- a/manifests/implementation/aws/elasticsearch/install.yaml
+++ b/manifests/implementation/aws/elasticsearch/install.yaml
@@ -465,7 +465,7 @@ spec:
                 - name: basicAuth
                   path: /yamls/basicAuth.yaml
             container:
-              image: ghcr.io/capactio/pr/infra/merger:PR-657
+              image: ghcr.io/capactio/infra/merger:2ada6f8
             outputs:
               artifacts:
               - name: merged

--- a/manifests/implementation/aws/rds/postgresql/install.yaml
+++ b/manifests/implementation/aws/rds/postgresql/install.yaml
@@ -266,7 +266,7 @@ spec:
                 - name: aws
                   path: /yamls/aws.yaml
             container:
-              image: ghcr.io/capactio/pr/infra/merger:PR-657
+              image: ghcr.io/capactio/infra/merger:2ada6f8
             outputs:
               artifacts:
               - name: merged

--- a/manifests/implementation/aws/redis/install.yaml
+++ b/manifests/implementation/aws/redis/install.yaml
@@ -260,7 +260,7 @@ spec:
                 - name: provider-credentials
                   path: /yamls/providercredentials.yaml
             container:
-              image: ghcr.io/capactio/pr/infra/merger:PR-657
+              image: ghcr.io/capactio/infra/merger:2ada6f8
             outputs:
               artifacts:
               - name: merged

--- a/manifests/implementation/aws/secrets-manager/storage/install.yaml
+++ b/manifests/implementation/aws/secrets-manager/storage/install.yaml
@@ -185,7 +185,7 @@ spec:
                   path: /yamls/additionalinput.yaml
                   optional: true
             container:
-              image: ghcr.io/capactio/pr/infra/merger:PR-657
+              image: ghcr.io/capactio/infra/merger:2ada6f8
             outputs:
               artifacts:
               - name: merged

--- a/manifests/implementation/bitnami/minio/install.yaml
+++ b/manifests/implementation/bitnami/minio/install.yaml
@@ -382,7 +382,7 @@ spec:
                   path: /yamls/additionalinput.yaml
                   optional: true
             container:
-              image: ghcr.io/capactio/pr/infra/merger:PR-657
+              image: ghcr.io/capactio/infra/merger:2ada6f8
             outputs:
               artifacts:
                 - name: merged

--- a/manifests/implementation/bitnami/mongodb/install.yaml
+++ b/manifests/implementation/bitnami/mongodb/install.yaml
@@ -406,7 +406,7 @@ spec:
                   path: /yamls/additionalinput.yaml
                   optional: true
             container:
-              image: ghcr.io/capactio/pr/infra/merger:PR-657
+              image: ghcr.io/capactio/infra/merger:2ada6f8
             outputs:
               artifacts:
                 - name: merged

--- a/manifests/implementation/bitnami/postgresql/install.yaml
+++ b/manifests/implementation/bitnami/postgresql/install.yaml
@@ -172,7 +172,7 @@ spec:
                 - name: ti-artifact
                   path: /tmp/output.yaml
             container:
-              image: ghcr.io/capactio/pr/ti-value-fetcher:PR-697
+              image: ghcr.io/capactio/ti-value-fetcher:2ada6f8
               env:
                 - name: APP_LOGGER_DEV_MODE
                   value: "true"

--- a/manifests/implementation/bitnami/postgresql/install.yaml
+++ b/manifests/implementation/bitnami/postgresql/install.yaml
@@ -87,7 +87,7 @@ spec:
             outputs:
               artifacts:
                 - name: postgresql
-                  from: "{{steps.resolve-ti-value.outputs.artifacts.ti-artifact}}"
+                  from: "{{steps.resolve-psql-value.outputs.artifacts.ti-artifact}}"
             steps:
               - - name: create-helm-args
                   capact-action: jinja2.template
@@ -129,10 +129,6 @@ spec:
 
               - - name: helm-install
                   capact-action: helm.install
-                  capact-outputTypeInstances: # Defines which artifacts are output TypeInstances
-                    - name: psql-helm-release
-                      from: helm-release
-                      backend: helm-release-storage
                   arguments:
                     artifacts:
                       - name: input-parameters
@@ -146,7 +142,8 @@ spec:
                         from: "{{inputs.artifacts.kubeconfig}}"
                         optional: true
 
-              - - name: resolve-ti-value
+              # allows reusing this workflow as a part of other umbrella workflows and read the artifact value
+              - - name: resolve-psql-value
                   template: resolve-ti-art-value
                   capact-outputTypeInstances:
                     - name: postgresql
@@ -159,25 +156,40 @@ spec:
                       - name: backend
                         from: "{{workflow.outputs.artifacts.helm-template-storage}}"
 
-          # TODO: PoC - create a proper container
+              # allows reusing this workflow as a part of other umbrella workflows and read the artifact value
+              - - name: resolve-helm-rel-value
+                  template: resolve-ti-art-value
+                  capact-outputTypeInstances:
+                    - name: psql-helm-release
+                      from: ti-artifact
+                      backend: helm-release-storage
+                  arguments:
+                    artifacts:
+                      - name: ti-artifact
+                        from: "{{steps.helm-install.outputs.artifacts.helm-release}}"
+                      - name: backend
+                        from: "{{workflow.outputs.artifacts.helm-release-storage}}"
+
           - name: resolve-ti-art-value
             inputs:
               artifacts:
                 - name: ti-artifact
-                  path: /ti.yaml
+                  path: /tmp/input-ti.yaml
                 - name: backend
-                  path: /backend.yaml
+                  path: /tmp/storage-backend.yaml
             outputs:
               artifacts:
                 - name: ti-artifact
-                  path: /ti.yaml              
+                  path: /tmp/output.yaml
             container:
-              image: alpine:latest
-              command: [ "sh", "-c" ]
-              args: [ "
-                  echo 'cat /ti.yaml' &&
-                  cat /ti.yaml || true &&
-                  echo 'cat /backend.yaml' &&
-                  cat /backend.yaml || true &&
-                  sleep 2 && echo 'value: foo' >> /ti.yaml && exit 0
-                 " ]
+              image: ghcr.io/capactio/pr/ti-value-fetcher:PR-697
+              env:
+                - name: APP_LOGGER_DEV_MODE
+                  value: "true"
+                - name: APP_INPUT_TI_FILE_PATH
+                  value: "{{inputs.artifacts.ti-artifact.path}}"
+                - name: APP_INPUT_BACKEND_TI_FILE_PATH
+                  value: "{{inputs.artifacts.backend.path}}"
+                - name: APP_OUTPUT_FILE_PATH
+                  value: "{{outputs.artifacts.ti-artifact.path}}"
+

--- a/manifests/implementation/bitnami/postgresql/install.yaml
+++ b/manifests/implementation/bitnami/postgresql/install.yaml
@@ -51,10 +51,9 @@ spec:
         - name: cap.type.helm.release.storage
           revision: 0.1.0
           alias: helm-release-storage
-# TODO: Uncomment once dynamic TypeInstances are supported in umbrella workflow
-#        - name: cap.type.helm.template.storage
-#          revision: 0.1.0
-#          alias: helm-template-storage
+        - name: cap.type.helm.template.storage
+          revision: 0.1.0
+          alias: helm-template-storage
 
   imports:
     - interfaceGroupPath: cap.interface.runner.helm
@@ -88,7 +87,7 @@ spec:
             outputs:
               artifacts:
                 - name: postgresql
-                  from: "{{steps.helm-install.outputs.artifacts.additional}}"
+                  from: "{{steps.resolve-ti-value.outputs.artifacts.ti-artifact}}"
             steps:
               - - name: create-helm-args
                   capact-action: jinja2.template
@@ -115,7 +114,7 @@ spec:
                               helmRelease:
                                 useHelmReleaseStorage: true
                               additional:
-                                useHelmTemplateStorage: false # TODO: Toggle to true and make sure it can be reused in umbrella workflows
+                                useHelmTemplateStorage: true
                                 goTemplate: |
                                   host: '{{ template "common.names.fullname" . }}.{{ .Release.Namespace }}'
                                   port: {{ template "postgresql.port" . }}
@@ -131,9 +130,6 @@ spec:
               - - name: helm-install
                   capact-action: helm.install
                   capact-outputTypeInstances: # Defines which artifacts are output TypeInstances
-                    - name: postgresql
-                      from: additional
-                      backend: helm-template-storage
                     - name: psql-helm-release
                       from: helm-release
                       backend: helm-release-storage
@@ -149,3 +145,39 @@ spec:
                       - name: kubeconfig
                         from: "{{inputs.artifacts.kubeconfig}}"
                         optional: true
+
+              - - name: resolve-ti-value
+                  template: resolve-ti-art-value
+                  capact-outputTypeInstances:
+                    - name: postgresql
+                      from: ti-artifact
+                      backend: helm-template-storage
+                  arguments:
+                    artifacts:
+                      - name: ti-artifact
+                        from: "{{steps.helm-install.outputs.artifacts.additional}}"
+                      - name: backend
+                        from: "{{workflow.outputs.artifacts.helm-template-storage}}"
+
+          # TODO: PoC - create a proper container
+          - name: resolve-ti-art-value
+            inputs:
+              artifacts:
+                - name: ti-artifact
+                  path: /ti.yaml
+                - name: backend
+                  path: /backend.yaml
+            outputs:
+              artifacts:
+                - name: ti-artifact
+                  path: /ti.yaml              
+            container:
+              image: alpine:latest
+              command: [ "sh", "-c" ]
+              args: [ "
+                  echo 'cat /ti.yaml' &&
+                  cat /ti.yaml || true &&
+                  echo 'cat /backend.yaml' &&
+                  cat /backend.yaml || true &&
+                  sleep 2 && echo 'value: foo' >> /ti.yaml && exit 0
+                 " ]

--- a/manifests/implementation/bitnami/postgresql/install.yaml
+++ b/manifests/implementation/bitnami/postgresql/install.yaml
@@ -129,6 +129,10 @@ spec:
 
               - - name: helm-install
                   capact-action: helm.install
+                  capact-outputTypeInstances:
+                    - name: psql-helm-release
+                      from: helm-release
+                      backend: helm-release-storage
                   arguments:
                     artifacts:
                       - name: input-parameters
@@ -155,20 +159,6 @@ spec:
                         from: "{{steps.helm-install.outputs.artifacts.additional}}"
                       - name: backend
                         from: "{{workflow.outputs.artifacts.helm-template-storage}}"
-
-              # allows reusing this workflow as a part of other umbrella workflows and read the artifact value
-              - - name: resolve-helm-rel-value
-                  template: resolve-ti-art-value
-                  capact-outputTypeInstances:
-                    - name: psql-helm-release
-                      from: ti-artifact
-                      backend: helm-release-storage
-                  arguments:
-                    artifacts:
-                      - name: ti-artifact
-                        from: "{{steps.helm-install.outputs.artifacts.helm-release}}"
-                      - name: backend
-                        from: "{{workflow.outputs.artifacts.helm-release-storage}}"
 
           - name: resolve-ti-art-value
             inputs:

--- a/manifests/implementation/bitnami/redis/install.yaml
+++ b/manifests/implementation/bitnami/redis/install.yaml
@@ -494,7 +494,7 @@ spec:
                   path: /yamls/additionalinput.yaml
                   optional: true
             container:
-              image: ghcr.io/capactio/pr/infra/merger:PR-657
+              image: ghcr.io/capactio/infra/merger:2ada6f8
             outputs:
               artifacts:
               - name: merged

--- a/manifests/implementation/concourse/concourse/install.yaml
+++ b/manifests/implementation/concourse/concourse/install.yaml
@@ -239,7 +239,7 @@ spec:
                 - name: user
                   path: /yamls/user.yaml
             container:
-              image: ghcr.io/capactio/pr/infra/merger:PR-657
+              image: ghcr.io/capactio/infra/merger:2ada6f8
             outputs:
               artifacts:
               - name: merged

--- a/manifests/implementation/gcp/cloudsql/postgresql/update.yaml
+++ b/manifests/implementation/gcp/cloudsql/postgresql/update.yaml
@@ -173,7 +173,7 @@ spec:
                 - name: postgresql
                   path: /yamls/postgresql.yaml
             container:
-              image: ghcr.io/capactio/pr/infra/merger:PR-657
+              image: ghcr.io/capactio/infra/merger:2ada6f8
             outputs:
               artifacts:
               - name: merged

--- a/manifests/implementation/helm/storage/install.yaml
+++ b/manifests/implementation/helm/storage/install.yaml
@@ -105,7 +105,7 @@ spec:
                             chart:
                               name: "helm-storage-backend"
                               repo: "https://storage.googleapis.com/capactio-latest-charts"
-                              version: <@ input.version | default("0.6.0-bf8d006") @>
+                              version: <@ input.version | default("0.6.0-2ada6f8") @>
                             values:
                               affinity: <@ additionalinput.affinity | default({}) | tojson @>
                               autoscaling:
@@ -115,7 +115,7 @@ spec:
                                 targetCPUUtilizationPercentage: <@ additionalinput.autoscaling.targetCPUUtilizationPercentage | default(80) @>
                               global:
                                 containerRegistry:
-                                  overrideTag: <@ additionalinput.global.containerRegistry.overrideTag | default("bf8d006") @>
+                                  overrideTag: <@ additionalinput.global.containerRegistry.overrideTag | default("2ada6f8") @>
                                   path: <@ additionalinput.global.containerRegistry.path | default("ghcr.io/capactio") @>
                               helmReleaseBackend:
                                 enabled: <@ additionalinput.helmReleaseBackend.enabled | default(true) | tojson @>
@@ -314,7 +314,7 @@ spec:
                   path: /yamls/additionalinput.yaml
                   optional: true
             container:
-              image: ghcr.io/capactio/pr/infra/merger:PR-657
+              image: ghcr.io/capactio/infra/merger:2ada6f8
             outputs:
               artifacts:
                 - name: merged

--- a/manifests/implementation/mattermost/mattermost-team-edition/install.yaml
+++ b/manifests/implementation/mattermost/mattermost-team-edition/install.yaml
@@ -504,7 +504,7 @@ spec:
                 - name: user
                   path: /yamls/user.yaml
             container:
-              image: ghcr.io/capactio/pr/infra/merger:PR-657
+              image: ghcr.io/capactio/infra/merger:2ada6f8
             outputs:
               artifacts:
               - name: merged
@@ -522,7 +522,7 @@ spec:
                 - name: ti-artifact
                   path: /tmp/output.yaml
             container:
-              image: ghcr.io/capactio/pr/ti-value-fetcher:PR-697
+              image: ghcr.io/capactio/ti-value-fetcher:2ada6f8
               env:
                 - name: APP_LOGGER_DEV_MODE
                   value: "true"

--- a/manifests/implementation/mattermost/mattermost-team-edition/install.yaml
+++ b/manifests/implementation/mattermost/mattermost-team-edition/install.yaml
@@ -109,6 +109,7 @@ spec:
                   capact-outputTypeInstances:
                     - name: postgresql
                       from: postgresql
+                      backend: helm-template-storage
                   arguments:
                     artifacts:
                       - name: input-parameters
@@ -463,6 +464,10 @@ spec:
 
               - - name: helm-install
                   capact-action: helm.install
+                  capact-outputTypeInstances:
+                    - name: mattermost-helm-release
+                      from: helm-release
+                      backend: helm-release-storage
                   arguments:
                     artifacts:
                       - name: input-parameters
@@ -483,20 +488,6 @@ spec:
                         from: "{{steps.helm-install.outputs.artifacts.additional}}"
                       - name: backend
                         from: "{{workflow.outputs.artifacts.helm-template-storage}}"
-
-              # allows reusing this workflow as a part of other umbrella workflows and read the artifact value
-              - - name: resolve-helm-rel-value
-                  template: resolve-ti-art-value
-                  capact-outputTypeInstances:
-                    - name: mattermost-helm-release
-                      from: ti-artifact
-                      backend: helm-release-storage
-                  arguments:
-                    artifacts:
-                      - name: ti-artifact
-                        from: "{{steps.helm-install.outputs.artifacts.helm-release}}"
-                      - name: backend
-                        from: "{{workflow.outputs.artifacts.helm-release-storage}}"
 
           - name: prepare-parameters
             inputs:

--- a/manifests/implementation/mattermost/mattermost-team-edition/install.yaml
+++ b/manifests/implementation/mattermost/mattermost-team-edition/install.yaml
@@ -118,8 +118,6 @@ spec:
                               username: superuser
                             defaultDBName: postgres
 
-              # TODO: Make PostgreSQL config TypeInstance dynamic and ensure it can be used in umbrella workflow
-
               - - name: create-user
                   capact-action: postgresql.create-user
                   capact-outputTypeInstances:

--- a/manifests/implementation/mattermost/mattermost-team-edition/install.yaml
+++ b/manifests/implementation/mattermost/mattermost-team-edition/install.yaml
@@ -100,7 +100,7 @@ spec:
             outputs:
               artifacts:
                 - name: mattermost-config
-                  from: "{{steps.helm-install.outputs.artifacts.additional}}"
+                  from: "{{steps.resolve-ti-value.outputs.artifacts.ti-artifact}}"
             steps:
               # Install DB
               - - name: install-db
@@ -463,19 +463,40 @@ spec:
 
               - - name: helm-install
                   capact-action: helm.install
-                  capact-outputTypeInstances:
-                    - name: mattermost-config
-                      from: additional
-                      backend: helm-template-storage
-                    - name: mattermost-helm-release
-                      from: helm-release
-                      backend: helm-release-storage
                   arguments:
                     artifacts:
                       - name: input-parameters
                         from: "{{steps.create-helm-args.outputs.artifacts.render}}"
                       - name: runner-context
                         from: "{{workflow.outputs.artifacts.runner-context}}"
+
+              # allows reusing this workflow as a part of other umbrella workflows and read the artifact value
+              - - name: resolve-ti-value
+                  template: resolve-ti-art-value
+                  capact-outputTypeInstances:
+                    - name: mattermost-config
+                      from: ti-artifact
+                      backend: helm-template-storage
+                  arguments:
+                    artifacts:
+                      - name: ti-artifact
+                        from: "{{steps.helm-install.outputs.artifacts.additional}}"
+                      - name: backend
+                        from: "{{workflow.outputs.artifacts.helm-template-storage}}"
+
+              # allows reusing this workflow as a part of other umbrella workflows and read the artifact value
+              - - name: resolve-helm-rel-value
+                  template: resolve-ti-art-value
+                  capact-outputTypeInstances:
+                    - name: mattermost-helm-release
+                      from: ti-artifact
+                      backend: helm-release-storage
+                  arguments:
+                    artifacts:
+                      - name: ti-artifact
+                        from: "{{steps.helm-install.outputs.artifacts.helm-release}}"
+                      - name: backend
+                        from: "{{workflow.outputs.artifacts.helm-release-storage}}"
 
           - name: prepare-parameters
             inputs:
@@ -497,3 +518,26 @@ spec:
               artifacts:
               - name: merged
                 path: /merged.yaml
+
+          - name: resolve-ti-art-value
+            inputs:
+              artifacts:
+                - name: ti-artifact
+                  path: /tmp/input-ti.yaml
+                - name: backend
+                  path: /tmp/storage-backend.yaml
+            outputs:
+              artifacts:
+                - name: ti-artifact
+                  path: /tmp/output.yaml
+            container:
+              image: ghcr.io/capactio/pr/ti-value-fetcher:PR-697
+              env:
+                - name: APP_LOGGER_DEV_MODE
+                  value: "true"
+                - name: APP_INPUT_TI_FILE_PATH
+                  value: "{{inputs.artifacts.ti-artifact.path}}"
+                - name: APP_INPUT_BACKEND_TI_FILE_PATH
+                  value: "{{inputs.artifacts.backend.path}}"
+                - name: APP_OUTPUT_FILE_PATH
+                  value: "{{outputs.artifacts.ti-artifact.path}}"

--- a/manifests/implementation/minio/mc/create_bucket.yaml
+++ b/manifests/implementation/minio/mc/create_bucket.yaml
@@ -135,7 +135,7 @@ spec:
                 - name: s3
                   path: /yamls/s3.yaml
             container:
-              image: ghcr.io/capactio/pr/infra/merger:PR-657
+              image: ghcr.io/capactio/infra/merger:2ada6f8
             outputs:
               artifacts:
               - name: merged

--- a/manifests/implementation/postgresql/change-password.yaml
+++ b/manifests/implementation/postgresql/change-password.yaml
@@ -125,7 +125,7 @@ spec:
                 - name: postgresql
                   path: /yamls/postgresql.yaml
             container:
-              image: ghcr.io/capactio/pr/infra/merger:PR-657
+              image: ghcr.io/capactio/infra/merger:2ada6f8
             outputs:
               artifacts:
               - name: merged

--- a/manifests/implementation/rocketchat/install.yaml
+++ b/manifests/implementation/rocketchat/install.yaml
@@ -273,7 +273,7 @@ spec:
                 - name: mongo
                   path: /yamls/mongo.yaml
             container:
-              image: ghcr.io/capactio/pr/infra/merger:PR-657
+              image: ghcr.io/capactio/infra/merger:2ada6f8
             outputs:
               artifacts:
                 - name: merged

--- a/manifests/implementation/runner/helm/install-static.yaml
+++ b/manifests/implementation/runner/helm/install-static.yaml
@@ -1,0 +1,99 @@
+ocfVersion: 0.0.1
+revision: 0.1.0
+kind: Implementation
+metadata:
+  prefix: cap.implementation.runner.helm
+  name: install-static
+  license:
+    name: "Apache 2.0"
+  displayName: "Install"
+  description: "Install action for Helm Runner which produces static Helm Release TypeInstance. It doesn't require Helm Release storage installed."
+  documentationURL: https://helm.sh/
+  maintainers:
+    - email: team-dev@capact.io
+      name: Capact Dev Team
+      url: https://capact.io
+
+spec:
+  appVersion: "3.x.x"
+
+  additionalInput:
+    typeInstances:
+      kubeconfig:
+        typeRef:
+          path: cap.type.containerization.kubernetes.kubeconfig
+          revision: 0.1.0
+        verbs: [ "get" ]
+
+  implements:
+    - path: cap.core.interface.runner.generic.run
+      revision: 0.1.0
+    - path: cap.interface.runner.helm.install
+      revision: 0.1.0
+
+  requires:
+    cap.core.type.platform:
+      oneOf:
+        - name: kubernetes
+          revision: 0.1.0
+
+  imports:
+    - interfaceGroupPath: cap.interface.runner.argo
+      alias: argo
+      methods:
+        - name: run
+          revision: 0.1.0
+
+  outputTypeInstanceRelations:
+    helm-release: {} # no dependencies
+    # Do not upload `additional` TypeInstance by default.
+    # Upper-level workflows may define it in the outputTypeInstanceRelations.
+
+  action:
+    runnerInterface: argo.run
+    args:
+      workflow:
+        entrypoint: helm
+        templates:
+          - name: helm
+            inputs:
+              artifacts:
+                # The input parameters that holds information what should be executed
+                - name: input-parameters
+                  path: "/runner-args"
+                - name: runner-context
+                  path: "/runner-context"
+                - name: kubeconfig
+                  path: "/kubeconfig-ti"
+                  optional: true
+            outputs:
+              artifacts:
+                - name: helm-release
+                  globalName: helm-release
+                  path: "/helm-release.yaml"
+                - name: additional
+                  path: "/additional.yaml"
+                  optional: true
+            volumes:
+              - name: tmp
+                emptyDir: { }
+            container:
+              image: ghcr.io/capactio/pr/helm-runner:PR-686
+              env:
+                - name: RUNNER_OPTIONAL_KUBECONFIG_TI
+                  value: "{{inputs.artifacts.kubeconfig.path}}"
+                - name: RUNNER_CONTEXT_PATH
+                  value: "{{inputs.artifacts.runner-context.path}}"
+                - name: RUNNER_ARGS_PATH
+                  value: "{{inputs.artifacts.input-parameters.path}}"
+                - name: RUNNER_LOGGER_DEV_MODE
+                  value: "true"
+                - name: RUNNER_COMMAND
+                  value: "install"
+                - name: RUNNER_OUTPUT_HELM_RELEASE_FILE_PATH
+                  value: "{{outputs.artifacts.helm-release.path}}"
+                - name: RUNNER_OUTPUT_ADDITIONAL_FILE_PATH
+                  value: "{{outputs.artifacts.additional.path}}"
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp

--- a/manifests/implementation/runner/helm/install-static.yaml
+++ b/manifests/implementation/runner/helm/install-static.yaml
@@ -78,7 +78,7 @@ spec:
               - name: tmp
                 emptyDir: { }
             container:
-              image: ghcr.io/capactio/pr/helm-runner:PR-686
+              image: ghcr.io/capactio/helm-runner:2ada6f8
               env:
                 - name: RUNNER_OPTIONAL_KUBECONFIG_TI
                   value: "{{inputs.artifacts.kubeconfig.path}}"

--- a/manifests/implementation/runner/helm/install.yaml
+++ b/manifests/implementation/runner/helm/install.yaml
@@ -122,7 +122,7 @@ spec:
               - name: tmp
                 emptyDir: { }
             container:
-              image: ghcr.io/capactio/pr/helm-runner:PR-686
+              image: ghcr.io/capactio/helm-runner:2ada6f8
               env:
                 - name: RUNNER_OPTIONAL_KUBECONFIG_TI
                   value: "{{inputs.artifacts.kubeconfig.path}}"
@@ -154,7 +154,7 @@ spec:
                 - name: ti-artifact
                   path: /tmp/output.yaml
             container:
-              image: ghcr.io/capactio/pr/ti-value-fetcher:PR-697
+              image: ghcr.io/capactio/ti-value-fetcher:2ada6f8
               env:
                 - name: APP_LOGGER_DEV_MODE
                   value: "true"

--- a/manifests/implementation/runner/helm/install.yaml
+++ b/manifests/implementation/runner/helm/install.yaml
@@ -36,6 +36,11 @@ spec:
       oneOf:
         - name: kubernetes
           revision: 0.1.0
+    cap.core.type.hub.storage:
+      allOf:
+        - name: cap.type.helm.release.storage
+          revision: 0.1.0
+          alias: helm-release-storage
 
   imports:
     - interfaceGroupPath: cap.interface.runner.argo
@@ -60,6 +65,46 @@ spec:
               artifacts:
                 # The input parameters that holds information what should be executed
                 - name: input-parameters
+                - name: runner-context
+                - name: kubeconfig
+                  optional: true
+            outputs:
+              artifacts:
+                - name: helm-release
+                  from: "{{steps.resolve-helm-rel-value.outputs.artifacts.ti-artifact}}"
+                - name: additional
+                  from: "{{steps.helm-install.outputs.artifacts.additional}}"
+            steps:
+              - - name: helm-install
+                  template: helm-install
+                  arguments:
+                    artifacts:
+                      - name: input-parameters
+                        from: "{{inputs.artifacts.input-parameters}}"
+                      - name: runner-context
+                        from: "{{inputs.artifacts.runner-context}}"
+                      - name: kubeconfig
+                        from: "{{inputs.artifacts.kubeconfig}}"
+
+              # allows reusing this workflow as a part of other umbrella workflows and read the artifact value
+              - - name: resolve-helm-rel-value
+                  template: resolve-ti-art-value
+                  capact-outputTypeInstances:
+                    - name: helm-release
+                      from: ti-artifact
+                      backend: helm-release-storage
+                  arguments:
+                    artifacts:
+                      - name: ti-artifact
+                        from: "{{steps.helm-install.outputs.artifacts.helm-release}}"
+                      - name: backend
+                        from: "{{workflow.outputs.artifacts.helm-release-storage}}"
+
+          - name: helm-install
+            inputs:
+              artifacts:
+                # The input parameters that holds information what should be executed
+                - name: input-parameters
                   path: "/runner-args"
                 - name: runner-context
                   path: "/runner-context"
@@ -69,7 +114,6 @@ spec:
             outputs:
               artifacts:
                 - name: helm-release
-                  globalName: helm-release
                   path: "/helm-release.yaml"
                 - name: additional
                   path: "/additional.yaml"
@@ -97,3 +141,26 @@ spec:
               volumeMounts:
                 - name: tmp
                   mountPath: /tmp
+
+          - name: resolve-ti-art-value
+            inputs:
+              artifacts:
+                - name: ti-artifact
+                  path: /tmp/input-ti.yaml
+                - name: backend
+                  path: /tmp/storage-backend.yaml
+            outputs:
+              artifacts:
+                - name: ti-artifact
+                  path: /tmp/output.yaml
+            container:
+              image: ghcr.io/capactio/pr/ti-value-fetcher:PR-697
+              env:
+                - name: APP_LOGGER_DEV_MODE
+                  value: "true"
+                - name: APP_INPUT_TI_FILE_PATH
+                  value: "{{inputs.artifacts.ti-artifact.path}}"
+                - name: APP_INPUT_BACKEND_TI_FILE_PATH
+                  value: "{{inputs.artifacts.backend.path}}"
+                - name: APP_OUTPUT_FILE_PATH
+                  value: "{{outputs.artifacts.ti-artifact.path}}"

--- a/manifests/implementation/runner/helm/upgrade.yaml
+++ b/manifests/implementation/runner/helm/upgrade.yaml
@@ -94,7 +94,7 @@ spec:
                   path: "/additional.yaml"
                   optional: true
             container:
-              image: ghcr.io/capactio/pr/helm-runner:PR-686
+              image: ghcr.io/capactio/helm-runner:2ada6f8
               env:
                 - name: RUNNER_CONTEXT_PATH
                   value: "{{inputs.artifacts.runner-context.path}}"

--- a/manifests/interface/helm/storage/install.yaml
+++ b/manifests/interface/helm/storage/install.yaml
@@ -40,7 +40,7 @@ spec:
                 "version": {
                   "$id": "#/properties/version",
                   "description": "Version",
-                  "default": "0.6.0-bf8d006",
+                  "default": "0.6.0-2ada6f8",
                   "$ref": "#/definitions/semVer"
                 }
               },

--- a/manifests/type/helm/storage/install-input.yaml
+++ b/manifests/type/helm/storage/install-input.yaml
@@ -65,7 +65,7 @@ spec:
                   "overrideTag": {
                     "type": "string",
                     "title": "OverrideTag",
-                    "default": "bf8d006",
+                    "default": "2ada6f8",
                     "$id": "#/properties/global/properties/containerRegistry/properties/overrideTag"
                   },
                   "path": {

--- a/manifests/type/runner/helm/install-input.yaml
+++ b/manifests/type/runner/helm/install-input.yaml
@@ -15,6 +15,7 @@ metadata:
 
 spec:
   jsonSchema:
+    # TODO(https://github.com/capactio/capact/issues/666): Remove output.useHelmTemplateStorage and use env in Helm Runner instead - as we have two Implementations.
     value: |-
       {
         "$schema": "http://json-schema.org/draft-07/schema",

--- a/manifests/type/runner/helm/upgrade-input.yaml
+++ b/manifests/type/runner/helm/upgrade-input.yaml
@@ -15,6 +15,7 @@ metadata:
 
 spec:
   jsonSchema:
+    # TODO(https://github.com/capactio/capact/issues/666): Remove output.useHelmTemplateStorage - detect input TypeInstance in Helm Runner and output the same shape
     value: |-
       {
         "$schema": "http://json-schema.org/draft-07/schema",


### PR DESCRIPTION
## Description

Changes proposed in this pull request:

- Use Helm template storage backend for PostgreSQL and Mattermost installation

## Notes

I needed to add a new Implementation for Helm Release, which doesn't require Helm Release storage and (in future) will always produce static Helm Release. I couldn't do it right now because of backward compatibility issues. I extended the scope of the https://github.com/capactio/capact/issues/666.

## Testing

1. Run Capact cluster from PR https://github.com/capactio/capact/pull/697
```bash
DISABLE_MONITORING_INSTALLATION=true make dev-cluster
```
1. Set manifests from my fork:
```bash
kubectl set env deploy/capact-hub-public -n capact-system -c hub-public-populator MANIFESTS_SOURCES="github.com/pkosiec/hub-manifests?ref=dynamic-ti-nested-workflows"
```
1. Install Helm Storage Backends via Dashboard
1. Use `ghcr.io/capactio/pr/helm-storage-backend:PR-697` for both Helm template and Helm release container
1. Update Global Policy:

```bash
ACTION_NAME="helm-storage" # your Action name which installed Helm storage backends
HELM_RELEASE_STORAGE_ID=$(capact act get $ACTION_NAME -ojson | jq '.Actions[0].output.typeInstances | map(select(.typeRef.path == "cap.type.helm.release.storage"))[0].id' -r)
HELM_TEMPLATE_STORAGE_ID=$(capact act get $ACTION_NAME -ojson | jq '.Actions[0].output.typeInstances | map(select(.typeRef.path == "cap.type.helm.template.storage"))[0].id' -r)

capact ti get $HELM_RELEASE_STORAGE_ID -oyaml
capact ti get $HELM_TEMPLATE_STORAGE_ID -oyaml

cat > /tmp/helm-storage-policy.yaml << ENDOFFILE
interface:
  default: # properties applied to all rules above
     inject:
       requiredTypeInstances:
          - id: ${HELM_TEMPLATE_STORAGE_ID}
            description: "Helm template"
          - id: ${HELM_RELEASE_STORAGE_ID}
            description: "Helm release"
  rules:
      - interface:
          path: cap.*
        oneOf:
        - implementationConstraints:
            requires:
            - path: cap.core.type.platform.kubernetes
        - implementationConstraints: {}
ENDOFFILE
capact policy apply -f /tmp/helm-storage-policy.yaml
```
1. Run Mattermost installation


## Related issue(s)

https://github.com/capactio/capact/issues/695