### PR TITLE
Fix manifests after fixing lost backend ID

### DIFF
--- a/manifests/implementation/bitnami/minio/install.yaml
+++ b/manifests/implementation/bitnami/minio/install.yaml
@@ -53,9 +53,6 @@ spec:
           revision: 0.1.0
     cap.core.type.hub.storage:
       allOf:
-        - name: cap.type.helm.release.storage
-          revision: 0.1.0
-          alias: helm-release-storage
         - name: cap.type.helm.template.storage
           revision: 0.1.0
           alias: helm-template-storage
@@ -370,8 +367,6 @@ spec:
                   capact-outputTypeInstances:
                     - name: helm-release
                       from: helm-release
-                      # Affected by https://github.com/capactio/capact/issues/705
-                      backend: helm-release-storage
                   arguments:
                     artifacts:
                       - name: input-parameters

--- a/manifests/implementation/bitnami/mongodb/install.yaml
+++ b/manifests/implementation/bitnami/mongodb/install.yaml
@@ -53,9 +53,6 @@ spec:
           revision: 0.1.0
     cap.core.type.hub.storage:
       allOf:
-        - name: cap.type.helm.release.storage
-          revision: 0.1.0
-          alias: helm-release-storage
         - name: cap.type.helm.template.storage
           revision: 0.1.0
           alias: helm-template-storage
@@ -395,8 +392,6 @@ spec:
                   capact-outputTypeInstances: # Defines which artifacts are output TypeInstances
                     - name: mongo-helm-release
                       from: helm-release
-                      # Affected by https://github.com/capactio/capact/issues/705
-                      backend: helm-release-storage
                   arguments:
                     artifacts:
                       - name: input-parameters

--- a/manifests/implementation/bitnami/postgresql/install.yaml
+++ b/manifests/implementation/bitnami/postgresql/install.yaml
@@ -48,9 +48,6 @@ spec:
           revision: 0.1.0
     cap.core.type.hub.storage:
       allOf:
-        - name: cap.type.helm.release.storage
-          revision: 0.1.0
-          alias: helm-release-storage
         - name: cap.type.helm.template.storage
           revision: 0.1.0
           alias: helm-template-storage

--- a/manifests/implementation/bitnami/postgresql/install.yaml
+++ b/manifests/implementation/bitnami/postgresql/install.yaml
@@ -132,7 +132,6 @@ spec:
                   capact-outputTypeInstances:
                     - name: psql-helm-release
                       from: helm-release
-                      backend: helm-release-storage
                   arguments:
                     artifacts:
                       - name: input-parameters

--- a/manifests/implementation/bitnami/redis/install.yaml
+++ b/manifests/implementation/bitnami/redis/install.yaml
@@ -40,9 +40,6 @@ spec:
           revision: 0.1.0
     cap.core.type.hub.storage:
       allOf:
-        - name: cap.type.helm.release.storage
-          revision: 0.1.0
-          alias: helm-release-storage
         - name: cap.type.helm.template.storage
           revision: 0.1.0
           alias: helm-template-storage
@@ -490,8 +487,6 @@ spec:
                   capact-outputTypeInstances:
                     - name: helm-release
                       from: helm-release
-                      # Affected by https://github.com/capactio/capact/issues/705
-                      backend: helm-release-storage
                   arguments:
                     artifacts:
                       - name: input-parameters

--- a/manifests/implementation/concourse/concourse/install.yaml
+++ b/manifests/implementation/concourse/concourse/install.yaml
@@ -46,9 +46,6 @@ spec:
           revision: 0.1.0
     cap.core.type.hub.storage:
       allOf:
-        - name: cap.type.helm.release.storage
-          revision: 0.1.0
-          alias: helm-release-storage
         - name: cap.type.helm.template.storage
           revision: 0.1.0
           alias: helm-template-storage
@@ -230,8 +227,6 @@ spec:
                   capact-outputTypeInstances:
                     - name: concourse-helm-release
                       from: helm-release
-                      # Affected by https://github.com/capactio/capact/issues/705
-                      backend: helm-release-storage
                   arguments:
                     artifacts:
                       - name: input-parameters

--- a/manifests/implementation/mattermost/mattermost-team-edition/install.yaml
+++ b/manifests/implementation/mattermost/mattermost-team-edition/install.yaml
@@ -50,9 +50,6 @@ spec:
           revision: 0.1.0
     cap.core.type.hub.storage:
       allOf:
-        - name: cap.type.helm.release.storage
-          revision: 0.1.0
-          alias: helm-release-storage
         - name: cap.type.helm.template.storage
           revision: 0.1.0
           alias: helm-template-storage
@@ -109,7 +106,6 @@ spec:
                   capact-outputTypeInstances:
                     - name: postgresql
                       from: postgresql
-                      backend: helm-template-storage
                   arguments:
                     artifacts:
                       - name: input-parameters
@@ -452,7 +448,7 @@ spec:
                               helmRelease:
                                 useHelmReleaseStorage: true
                               additional:
-                                useHelmTemplateStorage: true  
+                                useHelmTemplateStorage: true
                                 goTemplate: |
                                   host: "{{ index .Values.ingress.hosts 0 }}"
                                   version: "{{ .Values.image.tag }}"
@@ -467,7 +463,6 @@ spec:
                   capact-outputTypeInstances:
                     - name: mattermost-helm-release
                       from: helm-release
-                      backend: helm-release-storage
                   arguments:
                     artifacts:
                       - name: input-parameters

--- a/manifests/implementation/rocketchat/install.yaml
+++ b/manifests/implementation/rocketchat/install.yaml
@@ -48,9 +48,6 @@ spec:
           revision: 0.1.0
     cap.core.type.hub.storage:
       allOf:
-        - name: cap.type.helm.release.storage
-          revision: 0.1.0
-          alias: helm-release-storage
         - name: cap.type.helm.template.storage
           revision: 0.1.0
           alias: helm-template-storage
@@ -102,9 +99,6 @@ spec:
                   capact-outputTypeInstances:
                     - name: mongodb
                       from: mongodb
-                      # Affected by https://github.com/capactio/capact/issues/705
-                      # This needs to be removed to allow other non-Helm based Implementation
-                      backend: helm-template-storage
                   arguments:
                     artifacts:
                       - name: input-parameters
@@ -273,8 +267,6 @@ spec:
                   capact-outputTypeInstances:
                     - name: rocketchat-helm-release
                       from: helm-release
-                      # Affected by https://github.com/capactio/capact/issues/705
-                      backend: helm-release-storage
                   arguments:
                     artifacts:
                       - name: input-parameters


### PR DESCRIPTION
## Description

Changes proposed in this pull request:
- fix manifests after fixing lost backend ID

## Testing

I tested only Postgres + Mattermost installation as it would be fairly time-consuming to test all manifests. Although, the change is almost the same for untested manifests so it should be fine.

## Related issue(s)
- https://github.com/capactio/capact/issues/705
