### PR TITLE
Support for kubeconfig TypeInstance ID in Helm storage

### DIFF
--- a/manifests/implementation/helm/storage/install.yaml
+++ b/manifests/implementation/helm/storage/install.yaml
@@ -105,7 +105,7 @@ spec:
                             chart:
                               name: "helm-storage-backend"
                               repo: "https://storage.googleapis.com/capactio-latest-charts"
-                              version: <@ input.version | default("0.6.0-2ada6f8") @>
+                              version: <@ input.version | default("0.6.0-aaf8850") @>
                             values:
                               localHubEndpoint: <@ input.localHubEndpoint | default("http://capact-hub-local.capact-system/graphql") @>
                               kubeconfig:
@@ -118,7 +118,7 @@ spec:
                                 targetCPUUtilizationPercentage: <@ additionalinput.autoscaling.targetCPUUtilizationPercentage | default(80) @>
                               global:
                                 containerRegistry:
-                                  overrideTag: <@ additionalinput.global.containerRegistry.overrideTag | default("2ada6f8") @>
+                                  overrideTag: <@ additionalinput.global.containerRegistry.overrideTag | default("aaf8850") @>
                                   path: <@ additionalinput.global.containerRegistry.path | default("ghcr.io/capactio") @>
                               helmReleaseBackend:
                                 enabled: <@ additionalinput.helmReleaseBackend.enabled | default(true) | tojson @>

--- a/manifests/implementation/helm/storage/install.yaml
+++ b/manifests/implementation/helm/storage/install.yaml
@@ -104,7 +104,7 @@ spec:
                             generateName: true
                             chart:
                               name: "helm-storage-backend"
-                              repo: "https://storage.googleapis.com/capactio-commercial-stable-charts"
+                              repo: "https://storage.googleapis.com/capactio-latest-charts"
                               version: <@ input.version | default("0.6.0-2ada6f8") @>
                             values:
                               localHubEndpoint: <@ input.localHubEndpoint | default("http://capact-hub-local.capact-system/graphql") @>

--- a/manifests/implementation/helm/storage/install.yaml
+++ b/manifests/implementation/helm/storage/install.yaml
@@ -104,9 +104,12 @@ spec:
                             generateName: true
                             chart:
                               name: "helm-storage-backend"
-                              repo: "https://storage.googleapis.com/capactio-latest-charts"
+                              repo: "https://storage.googleapis.com/capactio-commercial-stable-charts"
                               version: <@ input.version | default("0.6.0-2ada6f8") @>
                             values:
+                              localHubEndpoint: <@ input.localHubEndpoint | default("http://capact-hub-local.capact-system/graphql") @>
+                              kubeconfig:
+                                typeInstanceID:  <@ input.kubeconfigTypeInstanceID | default("") @>
                               affinity: <@ additionalinput.affinity | default({}) | tojson @>
                               autoscaling:
                                 enabled: <@ additionalinput.autoscaling.enabled | default(false) | tojson @>

--- a/manifests/implementation/runner/helm/install-static.yaml
+++ b/manifests/implementation/runner/helm/install-static.yaml
@@ -78,7 +78,7 @@ spec:
               - name: tmp
                 emptyDir: { }
             container:
-              image: ghcr.io/capactio/helm-runner:2ada6f8
+              image: ghcr.io/capactio/pr/helm-runner:PR-716
               env:
                 - name: RUNNER_OPTIONAL_KUBECONFIG_TI
                   value: "{{inputs.artifacts.kubeconfig.path}}"

--- a/manifests/implementation/runner/helm/install-static.yaml
+++ b/manifests/implementation/runner/helm/install-static.yaml
@@ -78,7 +78,7 @@ spec:
               - name: tmp
                 emptyDir: { }
             container:
-              image: ghcr.io/capactio/pr/helm-runner:PR-716
+              image: ghcr.io/capactio/helm-runner:aaf8850
               env:
                 - name: RUNNER_OPTIONAL_KUBECONFIG_TI
                   value: "{{inputs.artifacts.kubeconfig.path}}"

--- a/manifests/implementation/runner/helm/install.yaml
+++ b/manifests/implementation/runner/helm/install.yaml
@@ -122,7 +122,7 @@ spec:
               - name: tmp
                 emptyDir: { }
             container:
-              image: ghcr.io/capactio/helm-runner:2ada6f8
+              image: ghcr.io/capactio/pr/helm-runner:PR-716
               env:
                 - name: RUNNER_OPTIONAL_KUBECONFIG_TI
                   value: "{{inputs.artifacts.kubeconfig.path}}"

--- a/manifests/implementation/runner/helm/install.yaml
+++ b/manifests/implementation/runner/helm/install.yaml
@@ -122,7 +122,7 @@ spec:
               - name: tmp
                 emptyDir: { }
             container:
-              image: ghcr.io/capactio/pr/helm-runner:PR-716
+              image: ghcr.io/capactio/helm-runner:aaf8850
               env:
                 - name: RUNNER_OPTIONAL_KUBECONFIG_TI
                   value: "{{inputs.artifacts.kubeconfig.path}}"

--- a/manifests/implementation/runner/helm/upgrade.yaml
+++ b/manifests/implementation/runner/helm/upgrade.yaml
@@ -94,7 +94,7 @@ spec:
                   path: "/additional.yaml"
                   optional: true
             container:
-              image: ghcr.io/capactio/helm-runner:2ada6f8
+              image: ghcr.io/capactio/pr/helm-runner:PR-716
               env:
                 - name: RUNNER_CONTEXT_PATH
                   value: "{{inputs.artifacts.runner-context.path}}"

--- a/manifests/implementation/runner/helm/upgrade.yaml
+++ b/manifests/implementation/runner/helm/upgrade.yaml
@@ -94,7 +94,7 @@ spec:
                   path: "/additional.yaml"
                   optional: true
             container:
-              image: ghcr.io/capactio/pr/helm-runner:PR-716
+              image: ghcr.io/capactio/helm-runner:aaf8850
               env:
                 - name: RUNNER_CONTEXT_PATH
                   value: "{{inputs.artifacts.runner-context.path}}"

--- a/manifests/interface/helm/storage/install.yaml
+++ b/manifests/interface/helm/storage/install.yaml
@@ -42,7 +42,19 @@ spec:
                   "description": "Version",
                   "default": "0.6.0-2ada6f8",
                   "$ref": "#/definitions/semVer"
-                }
+                },
+                "localHubEndpoint": {
+                  "$id": "#/properties/localHubEndpoint",
+                  "type": "string",
+                  "description": "Local Hub Endpoint",
+                  "default": "http://capact-hub-local.capact-system/graphql"
+                },
+                "kubeconfigTypeInstanceID": {
+                  "$id": "#/properties/kubeconfigTypeInstanceID",
+                  "type": "string",
+                  "description": "Kubeconfig TypeInstance ID",
+                  "default": ""
+                }  
               },
               "additionalProperties": false
             }

--- a/manifests/interface/helm/storage/install.yaml
+++ b/manifests/interface/helm/storage/install.yaml
@@ -40,7 +40,7 @@ spec:
                 "version": {
                   "$id": "#/properties/version",
                   "description": "Version",
-                  "default": "0.6.0-2ada6f8",
+                  "default": "0.6.0-aaf8850",
                   "$ref": "#/definitions/semVer"
                 },
                 "localHubEndpoint": {

--- a/manifests/type/helm/storage/install-input.yaml
+++ b/manifests/type/helm/storage/install-input.yaml
@@ -65,7 +65,7 @@ spec:
                   "overrideTag": {
                     "type": "string",
                     "title": "OverrideTag",
-                    "default": "2ada6f8",
+                    "default": "aaf8850",
                     "$id": "#/properties/global/properties/containerRegistry/properties/overrideTag"
                   },
                   "path": {


### PR DESCRIPTION
## Description

Changes proposed in this pull request:
- adds support for kubeconfig TypeInstance ID in Helm backend storage,
- use a new helm runner from this [PR](https://github.com/capactio/capact/pull/716)

## Related issue(s)
- https://github.com/capactio/capact/issues/715
